### PR TITLE
(fix): Rename Stellar assert auth macros for brevity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
  "cfg-if",
+ "paste",
  "soroban-sdk",
 ]
 
@@ -385,6 +386,7 @@ dependencies = [
  "goldie",
  "hex",
  "hex-literal",
+ "paste",
  "rand",
  "rand_chacha",
  "soroban-sdk",
@@ -395,6 +397,7 @@ name = "axelar-operators"
 version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
+ "paste",
  "soroban-sdk",
 ]
 
@@ -405,6 +408,7 @@ dependencies = [
  "axelar-soroban-std-derive",
  "goldie",
  "hex",
+ "paste",
  "soroban-sdk",
  "soroban-token-sdk",
 ]
@@ -414,6 +418,7 @@ name = "axelar-soroban-std-derive"
 version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
+ "paste",
  "proc-macro2",
  "quote",
  "soroban-sdk",
@@ -1159,6 +1164,7 @@ version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
  "cfg-if",
+ "paste",
  "soroban-sdk",
  "soroban-token-sdk",
 ]
@@ -1177,6 +1183,7 @@ dependencies = [
  "hex",
  "interchain-token",
  "interchain-token-service",
+ "paste",
  "soroban-sdk",
  "soroban-token-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ alloy-sol-types = { version = "0.8.14", default-features = false, features = [
 ] }
 goldie = "0.5.0"
 hex = { version = "0.4" }
+paste = "1.0"
 
 [workspace.lints.clippy]
 nursery = { level = "warn", priority = -1 }

--- a/contracts/axelar-gas-service/Cargo.toml
+++ b/contracts/axelar-gas-service/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 axelar-soroban-std = { workspace = true }
 cfg-if = { workspace = true }
 soroban-sdk = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }

--- a/contracts/axelar-gas-service/tests/test.rs
+++ b/contracts/axelar-gas-service/tests/test.rs
@@ -6,7 +6,7 @@ use std::format;
 use axelar_gas_service::error::ContractError;
 use axelar_gas_service::{AxelarGasService, AxelarGasServiceClient};
 use axelar_soroban_std::{
-    assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event, types::Token,
+    assert_contract_err, assert_auth_err, assert_last_emitted_event, types::Token,
 };
 use soroban_sdk::Bytes;
 use soroban_sdk::{
@@ -15,6 +15,7 @@ use soroban_sdk::{
     token::{StellarAssetClient, TokenClient},
     Address, Env, String, Symbol,
 };
+use paste::paste;
 
 fn setup_env<'a>() -> (Env, Address, Address, AxelarGasServiceClient<'a>) {
     let env = Env::default();
@@ -306,7 +307,7 @@ fn fail_collect_fees_unauthorized() {
 
     StellarAssetClient::new(&env, &token.address).mint(&contract_id, &supply);
 
-    assert_invoke_auth_err!(user, client.try_collect_fees(&user, &token));
+    assert_auth_err!(user, client.collect_fees(&user, &token));
 }
 
 #[test]
@@ -356,7 +357,7 @@ fn fail_refund_unauthorized() {
     let message_id = message_id(&env);
     let user: Address = Address::generate(&env);
 
-    assert_invoke_auth_err!(user, client.try_refund(&message_id, &receiver, &token));
+    assert_auth_err!(user, client.refund(&message_id, &receiver, &token));
 }
 
 #[test]

--- a/contracts/axelar-gateway/Cargo.toml
+++ b/contracts/axelar-gateway/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4"
 hex-literal = "0.4"
 rand = { version = "0.8.5" }
 soroban-sdk = { workspace = true, features = ["testutils"] }
+paste = { workspace = true }
 
 [features]
 library = [] # Only export the contract interface

--- a/contracts/axelar-gateway/tests/auth.rs
+++ b/contracts/axelar-gateway/tests/auth.rs
@@ -2,7 +2,7 @@ use axelar_gateway::error::ContractError;
 use axelar_gateway::testutils::{generate_proof, generate_signers_set, randint};
 use axelar_gateway::types::{ProofSignature, ProofSigner, WeightedSigner, WeightedSigners};
 use axelar_gateway::AxelarGateway;
-use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_ok};
+use axelar_soroban_std::{assert_contract_err, assert_auth};
 use soroban_sdk::{
     testutils::{Address as _, BytesN as _},
     Address, BytesN, Env, Vec,
@@ -10,6 +10,7 @@ use soroban_sdk::{
 
 mod utils;
 use utils::setup_env;
+use paste::paste;
 
 #[test]
 #[should_panic(expected = "Error(Contract, #13)")] // ContractError::InvalidSigners
@@ -287,9 +288,9 @@ fn rotate_signers_fail_duplicated_signers() {
 
     let data_hash = new_signers.signers.signers_rotation_hash(&env);
     let proof = generate_proof(&env, data_hash.clone(), signers);
-    assert_invoke_auth_ok!(
+    assert_auth!(
         client.operator(),
-        client.try_rotate_signers(&new_signers.signers, &proof, &true)
+        client.rotate_signers(&new_signers.signers, &proof, &true)
     );
 
     let proof = generate_proof(&env, data_hash, new_signers);
@@ -317,9 +318,9 @@ fn rotate_signers_panics_on_outdated_signer_set() {
         );
         let data_hash = new_signers.signers.signers_rotation_hash(&env);
         let proof = generate_proof(&env, data_hash, original_signers.clone());
-        assert_invoke_auth_ok!(
+        assert_auth!(
             client.operator(),
-            client.try_rotate_signers(&new_signers.signers, &proof, &true)
+            client.rotate_signers(&new_signers.signers, &proof, &true)
         );
     }
 
@@ -352,9 +353,9 @@ fn multi_rotate_signers() {
 
         let data_hash = new_signers.signers.signers_rotation_hash(&env);
         let proof = generate_proof(&env, data_hash.clone(), original_signers.clone());
-        assert_invoke_auth_ok!(
+        assert_auth!(
             client.operator(),
-            client.try_rotate_signers(&new_signers.signers, &proof, &true)
+            client.rotate_signers(&new_signers.signers, &proof, &true)
         );
 
         let proof = generate_proof(&env, msg_hash.clone(), new_signers.clone());

--- a/contracts/axelar-gateway/tests/gateway.rs
+++ b/contracts/axelar-gateway/tests/gateway.rs
@@ -9,13 +9,14 @@ use axelar_gateway::testutils::{
 };
 use axelar_gateway::types::Message;
 use axelar_soroban_std::{
-    assert_contract_err, assert_invocation, assert_invoke_auth_err, assert_invoke_auth_ok, events,
+    assert_contract_err, assert_invocation, assert_auth_err, assert_auth, events,
 };
 use soroban_sdk::{
     bytes,
     testutils::{Address as _, Events},
     vec, Address, BytesN, String,
 };
+use paste::paste;
 
 mod utils;
 use utils::setup_env;
@@ -32,9 +33,9 @@ fn call_contract() {
     let destination_address = String::from_str(&env, DESTINATION_ADDRESS);
     let payload = bytes!(&env, 0x1234);
 
-    assert_invoke_auth_ok!(
+    assert_auth!(
         user,
-        client.try_call_contract(&user, &destination_chain, &destination_address, &payload)
+        client.call_contract(&user, &destination_chain, &destination_address, &payload)
     );
 
     assert_invocation(
@@ -65,9 +66,9 @@ fn validate_message() {
 
     let prev_event_count = env.events().all().len();
 
-    let approved = assert_invoke_auth_ok!(
+    let approved = assert_auth!(
         contract_address,
-        client.try_validate_message(
+        client.validate_message(
             &contract_address,
             &source_chain,
             &message_id,
@@ -141,9 +142,9 @@ fn execute_approved_message() {
     let proof = generate_proof(&env, data_hash, signers);
     client.approve_messages(&messages, &proof);
 
-    let approved = assert_invoke_auth_ok!(
+    let approved = assert_auth!(
         contract_address,
-        client.try_validate_message(
+        client.validate_message(
             &contract_address,
             &source_chain,
             &message_id,
@@ -273,9 +274,9 @@ fn rotate_signers_bypass_rotation_delay() {
     let proof = generate_proof(&env, data_hash, signers);
     let bypass_rotation_delay = true;
 
-    assert_invoke_auth_ok!(
+    assert_auth!(
         client.operator(),
-        client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
+        client.rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
     );
 
     goldie::assert!(events::fmt_last_emitted_event::<SignersRotatedEvent>(&env));
@@ -291,15 +292,15 @@ fn rotate_signers_bypass_rotation_delay_unauthorized() {
     let proof = generate_proof(&env, data_hash, signers);
     let bypass_rotation_delay = true;
 
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         client.owner(),
-        client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
+        client.rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
     );
 
     let not_operator = Address::generate(&env);
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         not_operator,
-        client.try_rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
+        client.rotate_signers(&new_signers.signers, &proof, &bypass_rotation_delay)
     );
 }
 
@@ -329,13 +330,13 @@ fn transfer_operatorship_unauthorized() {
     let (env, _, client) = setup_env(1, randint(1, 10));
     let not_operator = Address::generate(&env);
 
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         client.owner(),
-        client.try_transfer_operatorship(&client.owner())
+        client.transfer_operatorship(&client.owner())
     );
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         not_operator,
-        client.try_transfer_operatorship(&not_operator)
+        client.transfer_operatorship(&not_operator)
     );
 }
 
@@ -345,10 +346,10 @@ fn transfer_ownership_unauthorized() {
 
     let new_owner = Address::generate(&env);
 
-    assert_invoke_auth_err!(new_owner, client.try_transfer_ownership(&new_owner));
-    assert_invoke_auth_err!(
+    assert_auth_err!(new_owner, client.transfer_ownership(&new_owner));
+    assert_auth_err!(
         client.operator(),
-        client.try_transfer_ownership(&client.operator())
+        client.transfer_ownership(&client.operator())
     );
 }
 
@@ -437,6 +438,6 @@ fn upgrade_unauthorized() {
     let not_owner = Address::generate(&env);
     let new_wasm_hash = BytesN::<32>::from_array(&env, &[0; 32]);
 
-    assert_invoke_auth_err!(not_owner, client.try_upgrade(&new_wasm_hash));
-    assert_invoke_auth_err!(client.operator(), client.try_upgrade(&new_wasm_hash));
+    assert_auth_err!(not_owner, client.upgrade(&new_wasm_hash));
+    assert_auth_err!(client.operator(), client.upgrade(&new_wasm_hash));
 }

--- a/contracts/axelar-operators/Cargo.toml
+++ b/contracts/axelar-operators/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 axelar-soroban-std = { workspace = true }
 soroban-sdk = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }

--- a/contracts/axelar-operators/tests/test.rs
+++ b/contracts/axelar-operators/tests/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 
 use axelar_operators::error::ContractError;
 use axelar_soroban_std::{
-    assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event,
+    assert_contract_err, assert_auth_err, assert_last_emitted_event,
     testutils::assert_invocation,
 };
 
@@ -11,6 +11,7 @@ use axelar_operators::{AxelarOperators, AxelarOperatorsClient};
 use soroban_sdk::{
     contract, contractimpl, symbol_short, testutils::Address as _, Address, Env, Symbol, Val, Vec,
 };
+use paste::paste;
 
 #[contract]
 pub struct TestTarget;
@@ -201,9 +202,9 @@ fn fail_execute_when_target_panics() {
     client.add_operator(&operator);
 
     // call execute as an operator
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         operator,
-        client.try_execute(
+        client.execute(
             &operator,
             &target,
             &symbol_short!("failing"),

--- a/contracts/interchain-token-service/Cargo.toml
+++ b/contracts/interchain-token-service/Cargo.toml
@@ -19,6 +19,7 @@ cfg-if = { workspace = true }
 interchain-token = { workspace = true, features = ["library"] }
 soroban-sdk = { workspace = true, features = ["alloc"] }
 soroban-token-sdk = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-gas-service = { workspace = true, features = ["testutils"] }

--- a/contracts/interchain-token-service/tests/deploy_interchain_token.rs
+++ b/contracts/interchain-token-service/tests/deploy_interchain_token.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use axelar_soroban_std::address::AddressExt;
 use axelar_soroban_std::assert_contract_err;
-use axelar_soroban_std::assert_invoke_auth_err;
+use axelar_soroban_std::assert_auth_err;
 use axelar_soroban_std::events;
 use interchain_token::InterchainTokenClient;
 use interchain_token_service::error::ContractError;
@@ -15,6 +15,7 @@ use soroban_sdk::BytesN;
 use soroban_token_sdk::metadata::TokenMetadata;
 use utils::setup_env;
 use utils::TokenMetadataExt;
+use paste::paste;
 
 #[test]
 fn deploy_interchain_token_succeeds() {
@@ -226,9 +227,9 @@ fn deploy_interchain_token_fails_with_invalid_auth() {
 
     let initial_supply = 100;
 
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         user,
-        client.try_deploy_interchain_token(
+        client.deploy_interchain_token(
             &sender,
             &salt,
             &token_metadata,

--- a/contracts/interchain-token-service/tests/executable.rs
+++ b/contracts/interchain-token-service/tests/executable.rs
@@ -3,12 +3,13 @@ mod utils;
 use axelar_gateway::testutils::{generate_proof, get_approve_hash};
 use axelar_gateway::types::Message as GatewayMessage;
 use axelar_soroban_std::traits::BytesExt;
-use axelar_soroban_std::{assert_invoke_auth_err, events};
+use axelar_soroban_std::{assert_auth_err, events};
 use interchain_token_service::types::{HubMessage, InterchainTransfer, Message};
 use soroban_sdk::token;
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{testutils::Address as _, vec, Address, Bytes, BytesN, String};
 use utils::{register_chains, setup_env, setup_its_token, HUB_CHAIN};
+use paste::paste;
 
 mod test {
     use axelar_soroban_std::{events::Event, impl_event_testutils};
@@ -188,9 +189,9 @@ fn executable_fails_if_not_executed_from_its() {
     let message_id = String::from_str(&env, "test");
     let payload = Bytes::from_hex(&env, "dead");
 
-    assert_invoke_auth_err!(
+    assert_auth_err!(
         Address::generate(&env),
-        executable_client.try_execute_with_interchain_token(
+        executable_client.execute_with_interchain_token(
             &source_chain,
             &message_id,
             &source_address,

--- a/contracts/interchain-token-service/tests/trusted_chain.rs
+++ b/contracts/interchain-token-service/tests/trusted_chain.rs
@@ -4,11 +4,12 @@ use interchain_token_service::event::{TrustedChainRemovedEvent, TrustedChainSetE
 use utils::setup_env;
 
 use axelar_soroban_std::{
-    assert_contract_err, assert_invoke_auth_err, assert_invoke_auth_ok, events,
+    assert_contract_err, assert_auth_err, assert_auth, events,
 };
 use interchain_token_service::error::ContractError;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Address, String};
+use paste::paste;
 
 #[test]
 fn set_trusted_address() {
@@ -16,7 +17,7 @@ fn set_trusted_address() {
 
     let chain = String::from_str(&env, "chain");
 
-    assert_invoke_auth_ok!(client.owner(), client.try_set_trusted_chain(&chain));
+    assert_auth!(client.owner(), client.set_trusted_chain(&chain));
 
     goldie::assert!(events::fmt_last_emitted_event::<TrustedChainSetEvent>(&env));
 
@@ -30,7 +31,7 @@ fn set_trusted_chain_fails_if_not_owner() {
     let not_owner = Address::generate(&env);
     let chain = String::from_str(&env, "chain");
 
-    assert_invoke_auth_err!(not_owner, client.try_set_trusted_chain(&chain));
+    assert_auth_err!(not_owner, client.set_trusted_chain(&chain));
 }
 
 #[test]
@@ -53,9 +54,9 @@ fn remove_trusted_chain() {
 
     let chain = String::from_str(&env, "chain");
 
-    assert_invoke_auth_ok!(client.owner(), client.try_set_trusted_chain(&chain));
+    assert_auth!(client.owner(), client.set_trusted_chain(&chain));
 
-    assert_invoke_auth_ok!(client.owner(), client.try_remove_trusted_chain(&chain));
+    assert_auth!(client.owner(), client.remove_trusted_chain(&chain));
 
     goldie::assert!(events::fmt_last_emitted_event::<TrustedChainRemovedEvent>(
         &env

--- a/contracts/interchain-token/Cargo.toml
+++ b/contracts/interchain-token/Cargo.toml
@@ -14,6 +14,7 @@ axelar-soroban-std = { workspace = true }
 cfg-if = { workspace = true }
 soroban-sdk = { workspace = true }
 soroban-token-sdk = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true, features = ["testutils"] }

--- a/packages/axelar-soroban-std-derive/Cargo.toml
+++ b/packages/axelar-soroban-std-derive/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 soroban-sdk = { workspace = true }
 syn = { version = "2.0", features = ["full"] }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std = { workspace = true }

--- a/packages/axelar-soroban-std-derive/tests/test.rs
+++ b/packages/axelar-soroban-std-derive/tests/test.rs
@@ -2,8 +2,9 @@ use soroban_sdk::{contract, contracterror, contractimpl, testutils::Address as _
 
 mod testdata;
 mod operatable {
-    use axelar_soroban_std::{assert_invoke_auth_ok, interfaces::OperatableClient};
+    use axelar_soroban_std::{assert_auth, interfaces::OperatableClient};
     use axelar_soroban_std_derive::Operatable;
+    use paste::paste;
 
     use super::*;
 
@@ -34,16 +35,17 @@ mod operatable {
         assert_eq!(operator, client.operator());
 
         let new_operator = Address::generate(&env);
-        assert_invoke_auth_ok!(operator, client.try_transfer_operatorship(&new_operator));
+        assert_auth!(operator, client.transfer_operatorship(&new_operator));
         assert_eq!(new_operator, client.operator());
     }
 }
 
 mod ownable {
-    use axelar_soroban_std::{assert_invoke_auth_ok, interfaces::OwnableClient};
+    use axelar_soroban_std::{assert_auth, interfaces::OwnableClient};
     use axelar_soroban_std_derive::Ownable;
 
     use super::*;
+    use paste::paste;
 
     #[contracterror]
     #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -72,16 +74,17 @@ mod ownable {
         assert_eq!(owner, client.owner());
 
         let new_owner = Address::generate(&env);
-        assert_invoke_auth_ok!(owner, client.try_transfer_ownership(&new_owner));
+        assert_auth!(owner, client.transfer_ownership(&new_owner));
         assert_eq!(new_owner, client.owner());
     }
 }
 
 mod upgradable {
-    use axelar_soroban_std::assert_invoke_auth_ok;
+    use axelar_soroban_std::assert_auth;
     use axelar_soroban_std_derive::{Ownable, Upgradable};
 
     use super::*;
+    use paste::paste;
 
     #[contracterror]
     #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -125,9 +128,9 @@ mod upgradable {
         let client = ContractClient::new(env, &contract_id);
         let new_wasm_hash = env.deployer().upload_contract_wasm(UPGRADED_WASM);
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&new_wasm_hash));
+        assert_auth!(owner, client.upgrade(&new_wasm_hash));
 
         let client = testdata::ContractClient::new(env, &contract_id);
-        assert_invoke_auth_ok!(owner, client.try_migrate(&()));
+        assert_auth!(owner, client.migrate(&()));
     }
 }

--- a/packages/axelar-soroban-std/Cargo.toml
+++ b/packages/axelar-soroban-std/Cargo.toml
@@ -14,6 +14,7 @@ axelar-soroban-std-derive = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 soroban-sdk = { workspace = true }
 soroban-token-sdk = { workspace = true }
+paste = { workspace = true }
 
 [dev-dependencies]
 axelar-soroban-std-derive = { workspace = true }

--- a/packages/axelar-soroban-std/src/error.rs
+++ b/packages/axelar-soroban-std/src/error.rs
@@ -106,13 +106,15 @@ macro_rules! assert_some {
 }
 
 #[macro_export]
-macro_rules! assert_invoke_auth_ok {
+macro_rules! assert_auth {
     ($caller:expr, $client:ident . $method:ident ( $($arg:expr),* $(,)? )) => {{
         use soroban_sdk::IntoVal;
 
-        let call_result = $client
-            .mock_auths($crate::mock_auth!($caller, $client, $method, $($arg),*))
-            .$method($($arg),*);
+        paste! {
+            let call_result = $client
+                .mock_auths($crate::mock_auth!($caller, $client, $method, $($arg),*))
+                .[<try_ $method>]($($arg),*);
+        }
 
         match call_result {
             Ok(outer) => {
@@ -127,14 +129,15 @@ macro_rules! assert_invoke_auth_ok {
 }
 
 #[macro_export]
-macro_rules! assert_invoke_auth_err {
+macro_rules! assert_auth_err {
     ($caller:expr, $client:ident . $method:ident ( $($arg:expr),* $(,)? )) => {{
         use soroban_sdk::{IntoVal, xdr::{ScError, ScErrorCode, ScVal}};
 
+        paste! {
         let call_result = $client
             .mock_auths($crate::mock_auth!($caller, $client, $method, $($arg),*))
-            .$method($($arg),*);
-
+            .[<try_ $method>]($($arg),*);
+        }
         match call_result {
             Err(_) => {
                 let val = ScVal::Error(ScError::Context(ScErrorCode::InvalidAction));

--- a/packages/axelar-soroban-std/src/interfaces/operatable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/operatable.rs
@@ -71,9 +71,10 @@ impl_event_testutils!(OperatorshipTransferredEvent, (Symbol, Address, Address), 
 mod test {
     use crate::interfaces::testdata::Contract;
     use crate::interfaces::{OperatableClient, OperatorshipTransferredEvent};
-    use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
+    use crate::{assert_auth_err, assert_auth, events};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, Env};
+    use paste::paste;
 
     fn prepare_client(env: &Env, operator: Option<Address>) -> OperatableClient {
         let owner = Address::generate(env);
@@ -105,9 +106,9 @@ mod test {
         let client = prepare_client(&env, Some(operator));
 
         let new_operator = Address::generate(&env);
-        assert_invoke_auth_err!(
+        assert_auth_err!(
             new_operator,
-            client.try_transfer_operatorship(&new_operator)
+            client.transfer_operatorship(&new_operator)
         );
     }
 
@@ -120,7 +121,7 @@ mod test {
         assert_eq!(client.operator(), operator);
 
         let new_operator = Address::generate(&env);
-        assert_invoke_auth_ok!(operator, client.try_transfer_operatorship(&new_operator));
+        assert_auth!(operator, client.transfer_operatorship(&new_operator));
 
         goldie::assert!(events::fmt_last_emitted_event::<OperatorshipTransferredEvent>(&env));
 

--- a/packages/axelar-soroban-std/src/interfaces/ownable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/ownable.rs
@@ -71,9 +71,10 @@ impl_event_testutils!(OwnershipTransferredEvent, (Symbol, Address, Address), ())
 mod test {
     use crate::interfaces::testdata::Contract;
     use crate::interfaces::{OwnableClient, OwnershipTransferredEvent};
-    use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
+    use crate::{assert_auth_err, assert_auth, events};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, Env};
+    use paste::paste;
 
     fn prepare_client(env: &Env, owner: Option<Address>) -> OwnableClient {
         let operator = Address::generate(env);
@@ -105,7 +106,7 @@ mod test {
         let client = prepare_client(&env, Some(owner));
 
         let new_owner = Address::generate(&env);
-        assert_invoke_auth_err!(new_owner, client.try_transfer_ownership(&new_owner));
+        assert_auth_err!(new_owner, client.transfer_ownership(&new_owner));
     }
 
     #[test]
@@ -117,7 +118,7 @@ mod test {
         assert_eq!(client.owner(), owner);
 
         let new_owner = Address::generate(&env);
-        assert_invoke_auth_ok!(owner, client.try_transfer_ownership(&new_owner));
+        assert_auth!(owner, client.transfer_ownership(&new_owner));
 
         goldie::assert!(events::fmt_last_emitted_event::<OwnershipTransferredEvent>(
             &env

--- a/packages/axelar-soroban-std/src/interfaces/upgradable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/upgradable.rs
@@ -107,12 +107,13 @@ pub enum MigrationError {
 #[cfg(test)]
 mod test {
     use crate::interfaces::upgradable::UpgradedEvent;
-    use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
+    use crate::{assert_auth_err, assert_auth, events};
 
     use crate::interfaces::testdata::{ContractClient, ContractNonTrivialClient, MigrationData};
     use crate::interfaces::{testdata, upgradable};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, BytesN, Env, String};
+    use paste::paste;
 
     const WASM: &[u8] = include_bytes!("testdata/contract_trivial_migration.wasm");
     const WASM_NON_TRIVIAL: &[u8] = include_bytes!("testdata/contract_non_trivial_migration.wasm");
@@ -151,7 +152,7 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner));
 
-        assert_invoke_auth_err!(Address::generate(&env), client.try_upgrade(&hash));
+        assert_auth_err!(Address::generate(&env), client.upgrade(&hash));
     }
 
     #[test]
@@ -160,7 +161,7 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
+        assert_auth!(owner, client.upgrade(&hash));
     }
 
     #[test]
@@ -169,7 +170,7 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
+        assert_auth!(owner, client.upgrade(&hash));
         assert!(client.try_migrate(&()).is_err());
     }
 
@@ -179,8 +180,8 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
-        assert_invoke_auth_err!(Address::generate(&env), client.try_migrate(&()));
+        assert_auth!(owner, client.upgrade(&hash));
+        assert_auth_err!(Address::generate(&env), client.migrate(&()));
     }
 
     #[test]
@@ -189,7 +190,7 @@ mod test {
         let owner = Address::generate(&env);
         let (client, _) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_err!(owner, client.try_migrate(&()));
+        assert_auth_err!(owner, client.migrate(&()));
     }
 
     #[test]
@@ -198,11 +199,11 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
+        assert_auth!(owner, client.upgrade(&hash));
 
         assert!(client.migration_data().is_none());
 
-        assert_invoke_auth_ok!(owner, client.try_migrate(&()));
+        assert_auth!(owner, client.migrate(&()));
 
         assert_eq!(
             client.migration_data(),
@@ -221,7 +222,7 @@ mod test {
         let hash = env.deployer().upload_contract_wasm(WASM_NON_TRIVIAL);
         let client = ContractNonTrivialClient::new(&env, &contract_id);
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
+        assert_auth!(owner, client.upgrade(&hash));
 
         assert!(client.migration_data().is_none());
 
@@ -231,7 +232,7 @@ mod test {
             data3: 42,
         };
 
-        assert_invoke_auth_ok!(owner, client.try_migrate(&data));
+        assert_auth!(owner, client.migrate(&data));
 
         assert_eq!(client.migration_data(), Some(data.data1));
 
@@ -251,7 +252,7 @@ mod test {
         });
 
         let client = ContractClient::new(&env, &contract_id);
-        assert_invoke_auth_ok!(owner, client.try_migrate(&()));
+        assert_auth!(owner, client.migrate(&()));
     }
 
     #[test]
@@ -260,8 +261,8 @@ mod test {
         let owner = Address::generate(&env);
         let (client, hash) = prepare_client_and_bytecode(&env, Some(owner.clone()));
 
-        assert_invoke_auth_ok!(owner, client.try_upgrade(&hash));
-        assert_invoke_auth_ok!(owner, client.try_migrate(&()));
-        assert_invoke_auth_err!(owner, client.try_migrate(&()));
+        assert_auth!(owner, client.upgrade(&hash));
+        assert_auth!(owner, client.migrate(&()));
+        assert_auth_err!(owner, client.migrate(&()));
     }
 }


### PR DESCRIPTION
[AXE-7063](https://axelarnetwork.atlassian.net/jira/software/c/projects/AXE/boards/21?selectedIssue=AXE-7063)



[AXE-7063]: https://axelarnetwork.atlassian.net/browse/AXE-7063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ