### PR TITLE
fix: make single contracts compilable again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,6 @@ name = "axelar-soroban-std-derive"
 version = "0.1.0"
 dependencies = [
  "axelar-soroban-std",
- "proc-macro2",
  "quote",
  "soroban-sdk",
  "syn 2.0.87",

--- a/packages/axelar-soroban-std-derive/Cargo.toml
+++ b/packages/axelar-soroban-std-derive/Cargo.toml
@@ -10,9 +10,7 @@ publish = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
 quote = "1.0"
-soroban-sdk = { workspace = true }
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The axelar-soroban-std package imports the soroban-sdk, and also imports the axelar-soroban-std-derive package, which in turn also imported the soroban-sdk. When now the testutils feature was active, the compiler couldn't resolve properly which soroban-sdk/testutils feature should get activated. By removing the soroban-sdk dependency from the derive package the ambiguity could be resolved and single contracts are compilable again without compiling the entire workspace