### PR TITLE
chore: use rustfmt nightly build to introduce opinionated imports ordering

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.81.0-nightly
+          toolchain: nightly
           components: rustfmt
 
       - name: Run cargo fmt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,11 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.81.0-nightly
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.81.0
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Rust Cache
         uses: useblacksmith/rust-cache@v3
@@ -33,9 +42,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-sort
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
 
       - name: Run cargo sort
         run: cargo-sort --workspace --check --check-format

--- a/contracts/axelar-gas-service/src/contract.rs
+++ b/contracts/axelar-gas-service/src/contract.rs
@@ -1,12 +1,12 @@
+use axelar_soroban_std::ttl::extend_instance_ttl;
+use axelar_soroban_std::types::Token;
+use axelar_soroban_std::{ensure, interfaces, Ownable, Upgradable};
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, String};
 
 use crate::error::ContractError;
 use crate::event;
 use crate::interface::AxelarGasServiceInterface;
 use crate::storage_types::DataKey;
-use axelar_soroban_std::ttl::extend_instance_ttl;
-use axelar_soroban_std::{ensure, interfaces, types::Token};
-use axelar_soroban_std::{Ownable, Upgradable};
 
 #[contract]
 #[derive(Ownable, Upgradable)]

--- a/contracts/axelar-gas-service/tests/test.rs
+++ b/contracts/axelar-gas-service/tests/test.rs
@@ -5,16 +5,11 @@ use std::format;
 
 use axelar_gas_service::error::ContractError;
 use axelar_gas_service::{AxelarGasService, AxelarGasServiceClient};
-use axelar_soroban_std::{
-    assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event, types::Token,
-};
-use soroban_sdk::Bytes;
-use soroban_sdk::{
-    bytes,
-    testutils::Address as _,
-    token::{StellarAssetClient, TokenClient},
-    Address, Env, String, Symbol,
-};
+use axelar_soroban_std::types::Token;
+use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{bytes, Address, Bytes, Env, String, Symbol};
 
 fn setup_env<'a>() -> (Env, Address, Address, AxelarGasServiceClient<'a>) {
     let env = Env::default();

--- a/contracts/axelar-gateway/src/auth.rs
+++ b/contracts/axelar-gateway/src/auth.rs
@@ -1,12 +1,12 @@
-use crate::error::ContractError;
-use crate::types::{ProofSignature, ProofSigner, WeightedSigner};
 use axelar_soroban_std::ensure;
 use axelar_soroban_std::events::Event;
-use soroban_sdk::{crypto::Hash, Bytes, BytesN, Env, Vec};
+use soroban_sdk::crypto::Hash;
+use soroban_sdk::{Bytes, BytesN, Env, Vec};
 
+use crate::error::ContractError;
 use crate::event::SignersRotatedEvent;
 use crate::storage_types::DataKey;
-use crate::types::{Proof, WeightedSigners};
+use crate::types::{Proof, ProofSignature, ProofSigner, WeightedSigner, WeightedSigners};
 
 pub fn initialize_auth(
     env: Env,

--- a/contracts/axelar-gateway/src/contract.rs
+++ b/contracts/axelar-gateway/src/contract.rs
@@ -1,3 +1,9 @@
+use axelar_soroban_std::events::Event;
+use axelar_soroban_std::ttl::extend_instance_ttl;
+use axelar_soroban_std::{ensure, interfaces, Operatable, Ownable, Upgradable};
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Vec};
+
 use crate::auth;
 use crate::error::ContractError;
 use crate::event::{ContractCalledEvent, MessageApprovedEvent, MessageExecutedEvent};
@@ -5,11 +11,6 @@ use crate::interface::AxelarGatewayInterface;
 use crate::messaging_interface::AxelarGatewayMessagingInterface;
 use crate::storage_types::{DataKey, MessageApprovalKey, MessageApprovalValue};
 use crate::types::{CommandType, Message, Proof, WeightedSigners};
-use axelar_soroban_std::events::Event;
-use axelar_soroban_std::ttl::extend_instance_ttl;
-use axelar_soroban_std::{ensure, interfaces, Operatable, Ownable, Upgradable};
-use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Vec};
 
 #[contract]
 #[derive(Ownable, Upgradable, Operatable)]

--- a/contracts/axelar-gateway/src/event.rs
+++ b/contracts/axelar-gateway/src/event.rs
@@ -1,10 +1,10 @@
-use crate::types::Message;
-
 use core::fmt::Debug;
 
 use axelar_soroban_std::events::Event;
 use cfg_if::cfg_if;
 use soroban_sdk::{Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Topics, Val, Vec};
+
+use crate::types::Message;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ContractCalledEvent {

--- a/contracts/axelar-gateway/src/interface.rs
+++ b/contracts/axelar-gateway/src/interface.rs
@@ -1,10 +1,9 @@
-use crate::{
-    error::ContractError,
-    types::{Message, Proof, WeightedSigners},
-    AxelarGatewayMessagingInterface,
-};
 use axelar_soroban_std::interfaces::{OperatableInterface, OwnableInterface, UpgradableInterface};
 use soroban_sdk::{contractclient, BytesN, Env, Vec};
+
+use crate::error::ContractError;
+use crate::types::{Message, Proof, WeightedSigners};
+use crate::AxelarGatewayMessagingInterface;
 
 #[contractclient(name = "AxelarGatewayClient")]
 pub trait AxelarGatewayInterface:

--- a/contracts/axelar-gateway/src/testutils.rs
+++ b/contracts/axelar-gateway/src/testutils.rs
@@ -1,21 +1,19 @@
 extern crate std;
 
-use crate::auth::{self, epoch};
-use crate::{AxelarGateway, AxelarGatewayClient};
+use axelar_soroban_std::traits::IntoVec;
 use axelar_soroban_std::{assert_last_emitted_event, assert_ok};
 use ed25519_dalek::{Signature, Signer, SigningKey};
 use rand::distributions::{Alphanumeric, DistString};
 use rand::Rng;
+use soroban_sdk::testutils::{Address as _, BytesN as _};
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{vec, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 
-use soroban_sdk::Symbol;
-use soroban_sdk::{testutils::Address as _, Address};
-use soroban_sdk::{testutils::BytesN as _, vec, xdr::ToXdr, Bytes, BytesN, Env, String, Vec};
-
+use crate::auth::{self, epoch};
 use crate::types::{
     CommandType, Message, Proof, ProofSignature, ProofSigner, WeightedSigner, WeightedSigners,
 };
-
-use axelar_soroban_std::traits::IntoVec;
+use crate::{AxelarGateway, AxelarGatewayClient};
 
 #[derive(Clone, Debug)]
 pub struct TestSignerSet {

--- a/contracts/axelar-gateway/src/types.rs
+++ b/contracts/axelar-gateway/src/types.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{contracttype, xdr::ToXdr, Address, BytesN, Env, String, Vec};
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{contracttype, Address, BytesN, Env, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -95,9 +96,11 @@ impl Proof {
 
 #[cfg(test)]
 mod test {
-    use crate::types::{CommandType, Message, WeightedSigner, WeightedSigners};
     use hex_literal::hex;
-    use soroban_sdk::{xdr::ToXdr, Address, BytesN, Env, String, Vec};
+    use soroban_sdk::xdr::ToXdr;
+    use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+    use crate::types::{CommandType, Message, WeightedSigner, WeightedSigners};
 
     #[test]
     fn weighted_signers_hash() {

--- a/contracts/axelar-gateway/tests/auth.rs
+++ b/contracts/axelar-gateway/tests/auth.rs
@@ -3,10 +3,8 @@ use axelar_gateway::testutils::{generate_proof, generate_signers_set, randint};
 use axelar_gateway::types::{ProofSignature, ProofSigner, WeightedSigner, WeightedSigners};
 use axelar_gateway::AxelarGateway;
 use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_ok};
-use soroban_sdk::{
-    testutils::{Address as _, BytesN as _},
-    Address, BytesN, Env, Vec,
-};
+use soroban_sdk::testutils::{Address as _, BytesN as _};
+use soroban_sdk::{Address, BytesN, Env, Vec};
 
 mod utils;
 use utils::setup_env;

--- a/contracts/axelar-gateway/tests/gateway.rs
+++ b/contracts/axelar-gateway/tests/gateway.rs
@@ -11,11 +11,8 @@ use axelar_gateway::types::Message;
 use axelar_soroban_std::{
     assert_contract_err, assert_invocation, assert_invoke_auth_err, assert_invoke_auth_ok, events,
 };
-use soroban_sdk::{
-    bytes,
-    testutils::{Address as _, Events},
-    vec, Address, BytesN, String,
-};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{bytes, vec, Address, BytesN, String};
 
 mod utils;
 use utils::setup_env;

--- a/contracts/axelar-gateway/tests/utils/mod.rs
+++ b/contracts/axelar-gateway/tests/utils/mod.rs
@@ -1,7 +1,5 @@
-use axelar_gateway::{
-    testutils::{setup_gateway, TestSignerSet},
-    AxelarGatewayClient,
-};
+use axelar_gateway::testutils::{setup_gateway, TestSignerSet};
+use axelar_gateway::AxelarGatewayClient;
 use soroban_sdk::Env;
 
 pub fn setup_env<'a>(

--- a/contracts/axelar-operators/src/contract.rs
+++ b/contracts/axelar-operators/src/contract.rs
@@ -1,9 +1,10 @@
-use crate::error::ContractError;
-use crate::event;
-use crate::storage_types::DataKey;
 use axelar_soroban_std::ttl::extend_instance_ttl;
 use axelar_soroban_std::{ensure, interfaces, Ownable, Upgradable};
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val, Vec};
+
+use crate::error::ContractError;
+use crate::event;
+use crate::storage_types::DataKey;
 
 #[contract]
 #[derive(Ownable, Upgradable)]

--- a/contracts/axelar-operators/tests/test.rs
+++ b/contracts/axelar-operators/tests/test.rs
@@ -2,15 +2,11 @@
 extern crate std;
 
 use axelar_operators::error::ContractError;
-use axelar_soroban_std::{
-    assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event,
-    testutils::assert_invocation,
-};
-
 use axelar_operators::{AxelarOperators, AxelarOperatorsClient};
-use soroban_sdk::{
-    contract, contractimpl, symbol_short, testutils::Address as _, Address, Env, Symbol, Val, Vec,
-};
+use axelar_soroban_std::testutils::assert_invocation;
+use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_err, assert_last_emitted_event};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol, Val, Vec};
 
 #[contract]
 pub struct TestTarget;

--- a/contracts/example/src/contract.rs
+++ b/contracts/example/src/contract.rs
@@ -1,12 +1,11 @@
-use crate::event;
 use axelar_gas_service::AxelarGasServiceClient;
+use axelar_gateway::executable::{AxelarExecutableInterface, NotApprovedError};
 use axelar_gateway::{impl_not_approved_error, AxelarGatewayMessagingClient};
 use axelar_soroban_std::types::Token;
 use soroban_sdk::{contract, contracterror, contractimpl, Address, Bytes, Env, String};
 
+use crate::event;
 use crate::storage_types::DataKey;
-
-use axelar_gateway::executable::{AxelarExecutableInterface, NotApprovedError};
 
 #[contract]
 pub struct Example;

--- a/contracts/example/tests/test.rs
+++ b/contracts/example/tests/test.rs
@@ -2,12 +2,11 @@
 extern crate std;
 
 use axelar_gas_service::{AxelarGasService, AxelarGasServiceClient};
-use axelar_gateway::{
-    testutils::{self, generate_proof, get_approve_hash, TestSignerSet},
-    types::Message,
-    AxelarGatewayClient,
-};
-use axelar_soroban_std::{assert_last_emitted_event, auth_invocation, types::Token};
+use axelar_gateway::testutils::{self, generate_proof, get_approve_hash, TestSignerSet};
+use axelar_gateway::types::Message;
+use axelar_gateway::AxelarGatewayClient;
+use axelar_soroban_std::types::Token;
+use axelar_soroban_std::{assert_last_emitted_event, auth_invocation};
 use example::{Example, ExampleClient};
 use soroban_sdk::testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, BytesN as _};
 use soroban_sdk::token::StellarAssetClient;

--- a/contracts/interchain-token-service/src/abi.rs
+++ b/contracts/interchain-token-service/src/abi.rs
@@ -244,11 +244,14 @@ impl From<MessageType> for U256 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloc::vec;
-    use axelar_soroban_std::{assert_ok, traits::BytesExt};
-    use soroban_sdk::{Bytes, BytesN, Env, String};
     use std::vec::Vec;
+
+    use axelar_soroban_std::assert_ok;
+    use axelar_soroban_std::traits::BytesExt;
+    use soroban_sdk::{Bytes, BytesN, Env, String};
+
+    use super::*;
 
     #[test]
     fn soroban_str_to_std_string() {

--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -1,3 +1,18 @@
+use axelar_gas_service::AxelarGasServiceClient;
+use axelar_gateway::executable::AxelarExecutableInterface;
+use axelar_gateway::AxelarGatewayMessagingClient;
+use axelar_soroban_std::address::AddressExt;
+use axelar_soroban_std::events::Event;
+use axelar_soroban_std::token::validate_token_metadata;
+use axelar_soroban_std::ttl::{extend_instance_ttl, extend_persistent_ttl};
+use axelar_soroban_std::types::Token;
+use axelar_soroban_std::{ensure, interfaces, Operatable, Ownable, Upgradable};
+use interchain_token::InterchainTokenClient;
+use soroban_sdk::token::{self, StellarAssetClient};
+use soroban_sdk::xdr::{FromXdr, ToXdr};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String};
+use soroban_token_sdk::metadata::TokenMetadata;
+
 use crate::abi::{get_message_type, MessageType as EncodedMessageType};
 use crate::error::ContractError;
 use crate::event::{
@@ -13,19 +28,6 @@ use crate::types::{
     DeployInterchainToken, HubMessage, InterchainTransfer, Message, TokenManagerType,
 };
 use crate::{flow_limit, token_handler};
-use axelar_gas_service::AxelarGasServiceClient;
-use axelar_gateway::{executable::AxelarExecutableInterface, AxelarGatewayMessagingClient};
-use axelar_soroban_std::events::Event;
-use axelar_soroban_std::token::validate_token_metadata;
-use axelar_soroban_std::ttl::{extend_instance_ttl, extend_persistent_ttl};
-use axelar_soroban_std::{
-    address::AddressExt, ensure, interfaces, types::Token, Operatable, Ownable, Upgradable,
-};
-use interchain_token::InterchainTokenClient;
-use soroban_sdk::token::{self, StellarAssetClient};
-use soroban_sdk::xdr::{FromXdr, ToXdr};
-use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String};
-use soroban_token_sdk::metadata::TokenMetadata;
 
 const ITS_HUB_CHAIN_NAME: &str = "axelar";
 const PREFIX_INTERCHAIN_TOKEN_ID: &str = "its-interchain-token-id";

--- a/contracts/interchain-token-service/src/flow_limit.rs
+++ b/contracts/interchain-token-service/src/flow_limit.rs
@@ -1,11 +1,11 @@
-use axelar_soroban_std::{ensure, events::Event, ttl::extend_persistent_ttl};
+use axelar_soroban_std::ensure;
+use axelar_soroban_std::events::Event;
+use axelar_soroban_std::ttl::extend_persistent_ttl;
 use soroban_sdk::{BytesN, Env};
 
-use crate::{
-    error::ContractError,
-    event::FlowLimitSetEvent,
-    storage_types::{DataKey, FlowKey},
-};
+use crate::error::ContractError;
+use crate::event::FlowLimitSetEvent;
+use crate::storage_types::{DataKey, FlowKey};
 
 const EPOCH_TIME: u64 = 6 * 60 * 60; // 6 hours in seconds = 21600
 

--- a/contracts/interchain-token-service/src/interface.rs
+++ b/contracts/interchain-token-service/src/interface.rs
@@ -3,7 +3,8 @@ use axelar_soroban_std::types::Token;
 use soroban_sdk::{contractclient, Address, Bytes, BytesN, Env, String};
 use soroban_token_sdk::metadata::TokenMetadata;
 
-use crate::{error::ContractError, types::TokenManagerType};
+use crate::error::ContractError;
+use crate::types::TokenManagerType;
 
 #[allow(dead_code)]
 #[contractclient(name = "InterchainTokenServiceClient")]

--- a/contracts/interchain-token-service/tests/deploy_interchain_token.rs
+++ b/contracts/interchain-token-service/tests/deploy_interchain_token.rs
@@ -1,20 +1,15 @@
 mod utils;
 
 use axelar_soroban_std::address::AddressExt;
-use axelar_soroban_std::assert_contract_err;
-use axelar_soroban_std::assert_invoke_auth_err;
-use axelar_soroban_std::events;
+use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_err, events};
 use interchain_token::InterchainTokenClient;
 use interchain_token_service::error::ContractError;
-
 use interchain_token_service::event::InterchainTokenDeployedEvent;
 use interchain_token_service::types::TokenManagerType;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::Address;
-use soroban_sdk::BytesN;
+use soroban_sdk::{Address, BytesN};
 use soroban_token_sdk::metadata::TokenMetadata;
-use utils::setup_env;
-use utils::TokenMetadataExt;
+use utils::{setup_env, TokenMetadataExt};
 
 #[test]
 fn deploy_interchain_token_succeeds() {

--- a/contracts/interchain-token-service/tests/deploy_remote_canonical_token.rs
+++ b/contracts/interchain-token-service/tests/deploy_remote_canonical_token.rs
@@ -1,9 +1,10 @@
 mod utils;
 
-use axelar_soroban_std::{address::AddressExt, auth_invocation, events};
-use interchain_token_service::{
-    event::InterchainTokenDeploymentStartedEvent,
-    types::{DeployInterchainToken, HubMessage, Message, TokenManagerType},
+use axelar_soroban_std::address::AddressExt;
+use axelar_soroban_std::{auth_invocation, events};
+use interchain_token_service::event::InterchainTokenDeploymentStartedEvent;
+use interchain_token_service::types::{
+    DeployInterchainToken, HubMessage, Message, TokenManagerType,
 };
 use soroban_sdk::testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation};
 use soroban_sdk::token::{self, StellarAssetClient};

--- a/contracts/interchain-token-service/tests/deploy_remote_interchain_token.rs
+++ b/contracts/interchain-token-service/tests/deploy_remote_interchain_token.rs
@@ -1,11 +1,9 @@
 mod utils;
 
 use axelar_soroban_std::{assert_contract_err, auth_invocation, events};
-use interchain_token_service::{
-    error::ContractError,
-    event::InterchainTokenDeploymentStartedEvent,
-    types::{DeployInterchainToken, HubMessage, Message},
-};
+use interchain_token_service::error::ContractError;
+use interchain_token_service::event::InterchainTokenDeploymentStartedEvent;
+use interchain_token_service::types::{DeployInterchainToken, HubMessage, Message};
 use soroban_sdk::testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation};
 use soroban_sdk::{Address, Bytes, BytesN, IntoVal, String, Symbol};
 use soroban_token_sdk::metadata::TokenMetadata;

--- a/contracts/interchain-token-service/tests/executable.rs
+++ b/contracts/interchain-token-service/tests/executable.rs
@@ -5,14 +5,16 @@ use axelar_gateway::types::Message as GatewayMessage;
 use axelar_soroban_std::traits::BytesExt;
 use axelar_soroban_std::{assert_invoke_auth_err, events};
 use interchain_token_service::types::{HubMessage, InterchainTransfer, Message};
-use soroban_sdk::token;
+use soroban_sdk::testutils::Address as _;
 use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{testutils::Address as _, vec, Address, Bytes, BytesN, String};
+use soroban_sdk::{token, vec, Address, Bytes, BytesN, String};
 use utils::{register_chains, setup_env, setup_its_token, HUB_CHAIN};
 
 mod test {
-    use axelar_soroban_std::{events::Event, impl_event_testutils};
     use core::fmt::Debug;
+
+    use axelar_soroban_std::events::Event;
+    use axelar_soroban_std::impl_event_testutils;
     use interchain_token_service::executable::InterchainTokenExecutableInterface;
     use soroban_sdk::{
         contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, IntoVal, String, Symbol,

--- a/contracts/interchain-token-service/tests/execute.rs
+++ b/contracts/interchain-token-service/tests/execute.rs
@@ -2,18 +2,18 @@ mod utils;
 
 use axelar_gateway::types::Message as GatewayMessage;
 use axelar_soroban_std::events;
+use interchain_token::InterchainTokenClient;
 use interchain_token_service::event::{
     InterchainTokenDeployedEvent, InterchainTransferReceivedEvent,
 };
 use interchain_token_service::types::{
     DeployInterchainToken, HubMessage, InterchainTransfer, Message, TokenManagerType,
 };
+use soroban_sdk::testutils::Address as _;
 use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{testutils::Address as _, vec, Address, Bytes, BytesN, String};
+use soroban_sdk::{vec, Address, Bytes, BytesN, String};
 use soroban_token_sdk::metadata::TokenMetadata;
 use utils::{approve_gateway_messages, register_chains, setup_env, setup_its_token, HUB_CHAIN};
-
-use interchain_token::InterchainTokenClient;
 
 #[test]
 #[should_panic(expected = "Error(Contract, #22)")] // ContractError::NotApproved

--- a/contracts/interchain-token-service/tests/flow_limit.rs
+++ b/contracts/interchain-token-service/tests/flow_limit.rs
@@ -1,15 +1,15 @@
 mod utils;
 
 use axelar_gateway::types::Message as GatewayMessage;
-use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_ok, events, traits::BytesExt};
-use interchain_token_service::{
-    error::ContractError,
-    event::FlowLimitSetEvent,
-    types::{HubMessage, InterchainTransfer, Message},
-    InterchainTokenServiceClient,
-};
+use axelar_soroban_std::traits::BytesExt;
+use axelar_soroban_std::{assert_contract_err, assert_invoke_auth_ok, events};
+use interchain_token_service::error::ContractError;
+use interchain_token_service::event::FlowLimitSetEvent;
+use interchain_token_service::types::{HubMessage, InterchainTransfer, Message};
+use interchain_token_service::InterchainTokenServiceClient;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
-use soroban_sdk::{vec, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{vec, Address, Bytes, BytesN, Env, String, Vec};
 use utils::{
     approve_gateway_messages, register_chains, setup_env, setup_gas_token, setup_its_token,
     HUB_CHAIN,

--- a/contracts/interchain-token-service/tests/interchain_transfer.rs
+++ b/contracts/interchain-token-service/tests/interchain_transfer.rs
@@ -3,7 +3,8 @@ mod utils;
 use axelar_soroban_std::events;
 use axelar_soroban_std::traits::BytesExt;
 use interchain_token_service::event::InterchainTransferSentEvent;
-use soroban_sdk::{testutils::Address as _, Address, Bytes, String};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Bytes, String};
 use utils::{register_chains, setup_env, setup_gas_token, setup_its_token};
 
 #[test]

--- a/contracts/interchain-token-service/tests/message_routing.rs
+++ b/contracts/interchain-token-service/tests/message_routing.rs
@@ -1,7 +1,10 @@
 mod utils;
-use axelar_soroban_std::{assert_contract_err, traits::BytesExt};
+use axelar_soroban_std::assert_contract_err;
+use axelar_soroban_std::traits::BytesExt;
 use interchain_token_service::error::ContractError;
-use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, Bytes, String};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{Address, Bytes, String};
 use utils::{register_chains, setup_env, setup_gas_token, setup_its_token};
 
 #[test]

--- a/contracts/interchain-token-service/tests/register_canonical_token.rs
+++ b/contracts/interchain-token-service/tests/register_canonical_token.rs
@@ -1,10 +1,13 @@
 mod utils;
 
-use axelar_soroban_std::{address::AddressExt, assert_contract_err, events};
-use interchain_token_service::{
-    error::ContractError, event::InterchainTokenIdClaimedEvent, types::TokenManagerType,
-};
-use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, BytesN};
+use axelar_soroban_std::address::AddressExt;
+use axelar_soroban_std::{assert_contract_err, events};
+use interchain_token_service::error::ContractError;
+use interchain_token_service::event::InterchainTokenIdClaimedEvent;
+use interchain_token_service::types::TokenManagerType;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{Address, BytesN};
 use utils::setup_env;
 
 #[test]

--- a/contracts/interchain-token-service/tests/trusted_chain.rs
+++ b/contracts/interchain-token-service/tests/trusted_chain.rs
@@ -1,14 +1,13 @@
 #[allow(dead_code)]
 mod utils;
-use interchain_token_service::event::{TrustedChainRemovedEvent, TrustedChainSetEvent};
-use utils::setup_env;
-
 use axelar_soroban_std::{
     assert_contract_err, assert_invoke_auth_err, assert_invoke_auth_ok, events,
 };
 use interchain_token_service::error::ContractError;
+use interchain_token_service::event::{TrustedChainRemovedEvent, TrustedChainSetEvent};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Address, String};
+use utils::setup_env;
 
 #[test]
 fn set_trusted_address() {

--- a/contracts/interchain-token-service/tests/utils/mod.rs
+++ b/contracts/interchain-token-service/tests/utils/mod.rs
@@ -1,10 +1,12 @@
 use axelar_gas_service::{AxelarGasService, AxelarGasServiceClient};
 use axelar_gateway::testutils::{generate_proof, get_approve_hash, setup_gateway, TestSignerSet};
-use axelar_gateway::{types::Message, AxelarGatewayClient};
+use axelar_gateway::types::Message;
+use axelar_gateway::AxelarGatewayClient;
 use axelar_soroban_std::types::Token;
 use interchain_token_service::{InterchainTokenService, InterchainTokenServiceClient};
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec};
-use soroban_sdk::{BytesN, IntoVal};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, BytesN, Env, IntoVal, String, Vec};
 use soroban_token_sdk::metadata::TokenMetadata;
 
 pub const HUB_CHAIN: &str = "axelar";

--- a/contracts/interchain-token/src/contract.rs
+++ b/contracts/interchain-token/src/contract.rs
@@ -1,23 +1,20 @@
+use axelar_soroban_std::interfaces::OwnableInterface;
 use axelar_soroban_std::token::validate_token_metadata;
 use axelar_soroban_std::ttl::{extend_instance_ttl, extend_persistent_ttl};
-use soroban_token_sdk::metadata::TokenMetadata;
-use soroban_token_sdk::TokenUtils;
-
-use crate::error::ContractError;
-use crate::event;
-use crate::storage_types::DataKey;
-
-use crate::interface::InterchainTokenInterface;
-use crate::storage_types::{AllowanceDataKey, AllowanceValue};
-use axelar_soroban_std::interfaces::OwnableInterface;
 use axelar_soroban_std::{ensure, interfaces, Upgradable};
 use soroban_sdk::token::{StellarAssetInterface, TokenInterface};
-
 use soroban_sdk::{
     assert_with_error, contract, contractimpl, panic_with_error, token, Address, BytesN, Env,
     String,
 };
 use soroban_token_sdk::event::Events as TokenEvents;
+use soroban_token_sdk::metadata::TokenMetadata;
+use soroban_token_sdk::TokenUtils;
+
+use crate::error::ContractError;
+use crate::event;
+use crate::interface::InterchainTokenInterface;
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
 
 #[contract]
 #[derive(Upgradable)]

--- a/contracts/interchain-token/src/interface.rs
+++ b/contracts/interchain-token/src/interface.rs
@@ -1,8 +1,5 @@
-use soroban_sdk::{
-    contractclient,
-    token::{self, StellarAssetInterface},
-    Address, BytesN, Env,
-};
+use soroban_sdk::token::{self, StellarAssetInterface};
+use soroban_sdk::{contractclient, Address, BytesN, Env};
 
 use crate::error::ContractError;
 

--- a/contracts/interchain-token/tests/test.rs
+++ b/contracts/interchain-token/tests/test.rs
@@ -4,12 +4,9 @@ extern crate std;
 use axelar_soroban_std::{
     assert_invoke_auth_err, assert_invoke_auth_ok, assert_last_emitted_event,
 };
-
 use interchain_token::{InterchainToken, InterchainTokenClient};
-use soroban_sdk::{
-    testutils::{Address as _, BytesN as _},
-    Address, BytesN, Env, IntoVal as _, Symbol,
-};
+use soroban_sdk::testutils::{Address as _, BytesN as _};
+use soroban_sdk::{Address, BytesN, Env, IntoVal as _, Symbol};
 use soroban_token_sdk::metadata::TokenMetadata;
 
 fn setup_token_metadata(env: &Env, name: &str, symbol: &str, decimal: u32) -> TokenMetadata {

--- a/contracts/upgrader/src/contract.rs
+++ b/contracts/upgrader/src/contract.rs
@@ -1,9 +1,10 @@
-use crate::error::ContractError;
 use axelar_soroban_std::ensure;
 use axelar_soroban_std::interfaces::UpgradableClient;
 use soroban_sdk::{
     contract, contractimpl, symbol_short, Address, BytesN, Env, String, Symbol, Val,
 };
+
+use crate::error::ContractError;
 
 const MIGRATE: Symbol = symbol_short!("migrate");
 

--- a/contracts/upgrader/tests/atomic_upgrades.rs
+++ b/contracts/upgrader/tests/atomic_upgrades.rs
@@ -1,8 +1,7 @@
 mod utils;
 
 use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
-use soroban_sdk::Address;
-use soroban_sdk::{BytesN, Env, String};
+use soroban_sdk::{Address, BytesN, Env, String};
 use upgrader::{Upgrader, UpgraderClient};
 use utils::{DataKey, DummyContract, DummyContractClient};
 

--- a/packages/axelar-soroban-std-derive/src/lib.rs
+++ b/packages/axelar-soroban-std-derive/src/lib.rs
@@ -1,8 +1,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    parse::Parse, parse::ParseStream, parse_macro_input, DeriveInput, Error, Ident, Token, Type,
-};
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, DeriveInput, Error, Ident, Token, Type};
 
 /// Implements the Operatable interface for a Soroban contract.
 ///

--- a/packages/axelar-soroban-std-derive/tests/test.rs
+++ b/packages/axelar-soroban-std-derive/tests/test.rs
@@ -1,8 +1,10 @@
-use soroban_sdk::{contract, contracterror, contractimpl, testutils::Address as _, Address, Env};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Env};
 
 mod testdata;
 mod operatable {
-    use axelar_soroban_std::{assert_invoke_auth_ok, interfaces::OperatableClient};
+    use axelar_soroban_std::assert_invoke_auth_ok;
+    use axelar_soroban_std::interfaces::OperatableClient;
     use axelar_soroban_std_derive::Operatable;
 
     use super::*;
@@ -40,7 +42,8 @@ mod operatable {
 }
 
 mod ownable {
-    use axelar_soroban_std::{assert_invoke_auth_ok, interfaces::OwnableClient};
+    use axelar_soroban_std::assert_invoke_auth_ok;
+    use axelar_soroban_std::interfaces::OwnableClient;
     use axelar_soroban_std_derive::Ownable;
 
     use super::*;

--- a/packages/axelar-soroban-std-derive/tests/testdata/contract.rs
+++ b/packages/axelar-soroban-std-derive/tests/testdata/contract.rs
@@ -1,6 +1,7 @@
+use core::fmt::Debug;
+
 use axelar_soroban_std::events::Event;
 use axelar_soroban_std_derive::{Ownable, Upgradable};
-use core::fmt::Debug;
 use soroban_sdk::{
     contract, contracterror, contractimpl, Address, Env, IntoVal, Symbol, Topics, Val,
 };

--- a/packages/axelar-soroban-std/src/events.rs
+++ b/packages/axelar-soroban-std/src/events.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
-use soroban_sdk::{Env, IntoVal, Topics, Val, Vec};
 
+use soroban_sdk::{Env, IntoVal, Topics, Val, Vec};
 #[cfg(any(test, feature = "testutils"))]
 pub use testutils::*;
 
@@ -19,9 +19,10 @@ pub trait Event: Debug + PartialEq {
 
 #[cfg(any(test, feature = "testutils"))]
 mod testutils {
-    use crate::events::Event;
     use soroban_sdk::testutils::Events;
     use soroban_sdk::{Address, Env, Val, Vec};
+
+    use crate::events::Event;
 
     pub trait EventTestutils: Event {
         fn matches(&self, env: &Env, event: &(Address, Vec<Val>, Val)) -> bool;
@@ -105,12 +106,14 @@ mod testutils {
 
 #[cfg(test)]
 mod test {
-    use crate::events::{Event, EventTestutils};
-    use crate::{events, impl_event_testutils};
     use core::fmt::Debug;
+
     use soroban_sdk::testutils::Events;
     use soroban_sdk::xdr::Int32;
     use soroban_sdk::{contract, BytesN, Env, IntoVal, String, Symbol, Topics, Val};
+
+    use crate::events::{Event, EventTestutils};
+    use crate::{events, impl_event_testutils};
 
     #[derive(Debug, PartialEq, Eq)]
     struct TestEvent {

--- a/packages/axelar-soroban-std/src/interfaces/operatable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/operatable.rs
@@ -1,9 +1,11 @@
+use core::fmt::Debug;
+
+use soroban_sdk::{contractclient, Address, Env, IntoVal, Symbol, Topics, Val, Vec};
+
 use crate::events::Event;
 #[cfg(any(test, feature = "testutils"))]
 use crate::impl_event_testutils;
 use crate::interfaces::storage;
-use core::fmt::Debug;
-use soroban_sdk::{contractclient, Address, Env, IntoVal, Symbol, Topics, Val, Vec};
 
 #[contractclient(name = "OperatableClient")]
 pub trait OperatableInterface {
@@ -69,11 +71,12 @@ impl_event_testutils!(OperatorshipTransferredEvent, (Symbol, Address, Address), 
 
 #[cfg(test)]
 mod test {
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
+
     use crate::interfaces::testdata::Contract;
     use crate::interfaces::{OperatableClient, OperatorshipTransferredEvent};
     use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
-    use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{Address, Env};
 
     fn prepare_client(env: &Env, operator: Option<Address>) -> OperatableClient {
         let owner = Address::generate(env);

--- a/packages/axelar-soroban-std/src/interfaces/ownable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/ownable.rs
@@ -1,9 +1,11 @@
+use core::fmt::Debug;
+
+use soroban_sdk::{contractclient, Address, Env, IntoVal, Symbol, Topics, Val, Vec};
+
 use crate::events::Event;
 #[cfg(any(test, feature = "testutils"))]
 use crate::impl_event_testutils;
 use crate::interfaces::storage;
-use core::fmt::Debug;
-use soroban_sdk::{contractclient, Address, Env, IntoVal, Symbol, Topics, Val, Vec};
 
 #[contractclient(name = "OwnableClient")]
 pub trait OwnableInterface {
@@ -69,11 +71,12 @@ impl_event_testutils!(OwnershipTransferredEvent, (Symbol, Address, Address), ())
 
 #[cfg(test)]
 mod test {
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
+
     use crate::interfaces::testdata::Contract;
     use crate::interfaces::{OwnableClient, OwnershipTransferredEvent};
     use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
-    use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{Address, Env};
 
     fn prepare_client(env: &Env, owner: Option<Address>) -> OwnableClient {
         let operator = Address::generate(env);

--- a/packages/axelar-soroban-std/src/interfaces/testdata/contract_non_trivial_migration.rs
+++ b/packages/axelar-soroban-std/src/interfaces/testdata/contract_non_trivial_migration.rs
@@ -1,10 +1,10 @@
 // this is only needed in this crate itself, any crate that imports this one doesn't have to do this manual import resolution
-use crate as axelar_soroban_std;
-
-use crate::interfaces::testdata::contract_trivial_migration::DataKey;
-use crate::interfaces::{operatable, ownable, MigratableInterface};
 use axelar_soroban_std_derive::{Ownable, Upgradable};
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+
+use crate as axelar_soroban_std;
+use crate::interfaces::testdata::contract_trivial_migration::DataKey;
+use crate::interfaces::{operatable, ownable, MigratableInterface};
 
 #[derive(Upgradable, Ownable)]
 #[migratable(with_type = MigrationData)]

--- a/packages/axelar-soroban-std/src/interfaces/testdata/contract_trivial_migration.rs
+++ b/packages/axelar-soroban-std/src/interfaces/testdata/contract_trivial_migration.rs
@@ -1,10 +1,11 @@
-use crate::interfaces::{
-    operatable, ownable, upgradable, MigratableInterface, OperatableInterface, OwnableInterface,
-    UpgradableInterface,
-};
 use soroban_sdk::testutils::arbitrary::std;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String,
+};
+
+use crate::interfaces::{
+    operatable, ownable, upgradable, MigratableInterface, OperatableInterface, OwnableInterface,
+    UpgradableInterface,
 };
 
 #[contract]

--- a/packages/axelar-soroban-std/src/interfaces/upgradable.rs
+++ b/packages/axelar-soroban-std/src/interfaces/upgradable.rs
@@ -1,12 +1,14 @@
+use core::fmt::Debug;
+
+use soroban_sdk::{
+    contractclient, symbol_short, BytesN, Env, FromVal, IntoVal, String, Topics, Val,
+};
+
 use crate::ensure;
 use crate::events::Event;
 #[cfg(any(test, feature = "testutils"))]
 use crate::impl_event_testutils;
 use crate::interfaces::{storage, OwnableInterface};
-use core::fmt::Debug;
-use soroban_sdk::{
-    contractclient, symbol_short, BytesN, Env, FromVal, IntoVal, String, Topics, Val,
-};
 
 #[contractclient(name = "UpgradableClient")]
 pub trait UpgradableInterface: OwnableInterface {
@@ -106,13 +108,13 @@ pub enum MigrationError {
 
 #[cfg(test)]
 mod test {
-    use crate::interfaces::upgradable::UpgradedEvent;
-    use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
-
-    use crate::interfaces::testdata::{ContractClient, ContractNonTrivialClient, MigrationData};
-    use crate::interfaces::{testdata, upgradable};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, BytesN, Env, String};
+
+    use crate::interfaces::testdata::{ContractClient, ContractNonTrivialClient, MigrationData};
+    use crate::interfaces::upgradable::UpgradedEvent;
+    use crate::interfaces::{testdata, upgradable};
+    use crate::{assert_invoke_auth_err, assert_invoke_auth_ok, events};
 
     const WASM: &[u8] = include_bytes!("testdata/contract_trivial_migration.wasm");
     const WASM_NON_TRIVIAL: &[u8] = include_bytes!("testdata/contract_non_trivial_migration.wasm");

--- a/packages/axelar-soroban-std/src/testutils.rs
+++ b/packages/axelar-soroban-std/src/testutils.rs
@@ -1,10 +1,8 @@
 #![cfg(any(test, feature = "testutils"))]
 extern crate std;
 
-use soroban_sdk::{
-    testutils::{AuthorizedFunction, AuthorizedInvocation, Events},
-    vec, Address, Env, IntoVal, Symbol, Val, Vec,
-};
+use soroban_sdk::testutils::{AuthorizedFunction, AuthorizedInvocation, Events};
+use soroban_sdk::{vec, Address, Env, IntoVal, Symbol, Val, Vec};
 
 /// Asserts invocation auth of a contract from a single caller.
 pub fn assert_invocation<T>(

--- a/packages/axelar-soroban-std/src/token.rs
+++ b/packages/axelar-soroban-std/src/token.rs
@@ -1,6 +1,7 @@
-use crate::ensure;
 use soroban_sdk::contracterror;
 use soroban_token_sdk::metadata::TokenMetadata;
+
+use crate::ensure;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
only the rustfmt.toml and the lint.yaml have actually changed, the rest is automated import reordering