### PR TITLE
chore: release v0.1.0

### DIFF
--- a/contracts/axelar-gas-service/CHANGELOG.md
+++ b/contracts/axelar-gas-service/CHANGELOG.md
@@ -42,6 +42,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
 - Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))
 
+### 🧪 Testing
+
+- Improve test coverage ([#163](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/163)) - ([d753e51](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d753e51b535c6234f81017a55e81046128c958bd))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update workspace dependencies ([#158](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/158)) - ([f214826](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f214826c4695fdf0d25e6298a94c415fa8ea1ff0))
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
+- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
+- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))
+
+### Contributors
+
+* @AttissNgo
+* @milapsheth
+* @talalashraf
+* @TanvirDeol
+* @ahramy
+* @cgorenflo
+* @hydrobeam
+* @apolikamixitos
+* @canhtrinh
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
+- *(gas-service)* Add contract constructor ([#72](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/72)) - ([2d5e74c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2d5e74c5eaa07eb4ede4a287d13d6be25c5212b7))
+- *(gas-service)* Add gas function in gas service ([#59](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/59)) - ([270bd85](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/270bd85c32f9cd90285134be1b4a9fd2878402ff))
+- *(gas-service)* Improve error handling ([#26](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/26)) - ([d330956](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d330956385ebdfc37455a824ce4e66e106ae34e4))
+- *(its)* Add skeleton code for its token deployment ([#88](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/88)) - ([b062cf1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b062cf1eb9f26ef2ceeebeded732fd40e58f48f4))
+- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
+- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+- Allow exporting soroban contract crates are libraries ([#80](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/80)) - ([22cf5ab](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/22cf5ab2246c93834787f311f2b4898ae897cb75))
+- Gmp example contract ([#62](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/62)) - ([fe4859d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/fe4859dd50e8ff922e8c363ae8c77ef0f772850a))
+- Upgrade `soroban-sdk` version to `v21.7.6` ([#50](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/50)) - ([f4efa15](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f4efa1545926199c7deae8b864abc1858d9cb6a9))
+- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
+- Gas service ([#3](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/3)) - ([64fdccf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/64fdccf8131d045a2c2785f91d1c79999c89c4cd))
+
+### 🐛 Bug Fixes
+
+- *(axelar-gas-service)* [**breaking**] Fix axlear gas service add_gas ([#89](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/89)) - ([20593c0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/20593c021448fd0522fee003b1ae56a3b74f3dd7))
+- *(axelar-gas-service)* [**breaking**] Fix axelar gas service pay_gas ([#83](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/83)) - ([6803ae7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6803ae766298c764b4fe8606af7a1309b8d2dff3))
+
+### 🚜 Refactor
+
+- *(axelar-gas-service)* Move run_migration into separate impl block ([#91](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/91)) - ([ce8d3af](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ce8d3af09bff15b85d94b5a2502806411a62374e))
+- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
+- *(gas-service,operators)* Move out of `axelar-soroban-interfaces` ([#43](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/43)) - ([c7a9d9f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c7a9d9f6b2f346efa4b1f836f00bd591eea84be8))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))
+
 ### ⚙️ Miscellaneous Tasks
 
 - Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))

--- a/contracts/axelar-gateway/CHANGELOG.md
+++ b/contracts/axelar-gateway/CHANGELOG.md
@@ -99,6 +99,137 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(axelar-gateway)* Add golden test for weighted signers ([#37](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/37)) - ([0456b04](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0456b044076659c278dfb46868bf39323d8b5895))
 - *(axelar-gateway)* Re-introduce auth-verifier tests ([#33](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/33)) - ([bfcf45d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bfcf45d2a893a00fadf69a824ac696f350327582))
 - *(gateway)* Reuse domain separator for rotate signer tests - ([b80e35b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b80e35b66e39ab448f72db9e878c7423dd535a57))
+- Improve test coverage ([#163](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/163)) - ([d753e51](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d753e51b535c6234f81017a55e81046128c958bd))
+- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))
+- Add expected invoke auth error for unit tests ([#52](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/52)) - ([890bfcf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/890bfcfc92badf0ffed2c90aa581efdac4ce81dc))
+- Support negative indexing for asserting emitted events - ([4d57a62](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d57a62689b4c93662efd8b78bdf6d772975db63))
+- Add axelar-gateway testutils - ([360263a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/360263a90778490a9b6e0e9a579314118e099b43))
+- Use auth testutil initialize in gateway tests - ([d885c00](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d885c00012120b39ba8895d5bc88df67a07ede1c))
+- Make axelar gateway tests use auth testutils - ([e602831](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e6028310a5adcd75c315f82f697aa7886bcfa6dd))
+- Refactor gateway test to use testutils - ([3ee43f8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3ee43f89fd7a15612da69cfc534dd19117aced87))
+- Simplify testutils using IntoVal<> - ([9779bef](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9779bef9a70564f1222f227d852b8620fa446d85))
+- Fix test compilation issues - ([5c5b715](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5c5b71562b72dcf0d9b32747ee4b81175267b00e))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(gateway)* Coverage for upgrade and version ([#45](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/45)) - ([0a40b39](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0a40b3945877d9d62ab8f0f16f8cda6945a4116e))
+- Update workspace dependencies ([#158](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/158)) - ([f214826](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f214826c4695fdf0d25e6298a94c415fa8ea1ff0))
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
+- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
+- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))
+- Cargo sort - ([3e08c3b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e08c3beab4cf91d1513417febf5d1618685432f))
+- Lint files - ([756cc99](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/756cc99b8a5823cbad6a1761546af28d56da3636))
+- Remove duplicate gateway interface - ([23c86b2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/23c86b2cf03c3a6ca1a8c8192c3346175fcf2700))
+- Add gateway contract TODOs - ([0802231](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0802231237037c3ffea026433d0c426e2d5b2f42))
+- Add gateway as a dep to workspace - ([1cb795d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1cb795d5804d4009c209def50d71507690fb5331))
+- Cargo fmt axelar gateway - ([7d07fdb](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7d07fdb02b9d513da6e299f20fc6262fd0c8f65c))
+
+### Contributors
+
+* @AttissNgo
+* @milapsheth
+* @talalashraf
+* @nbayindirli
+* @TanvirDeol
+* @ahramy
+* @cgorenflo
+* @hydrobeam
+* @apolikamixitos
+* @deanamiel
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(amplifier)* Gateway v2 - ([948296d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/948296d1397e4ca93341b79e9f1d6f761edb99c6))
+- *(amplifier)* Auth v2 - ([b455faa](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b455faac7600aa78fb0ebde2b4f48f1914cd154e))
+- *(amplifier)* Add gateway v2 interface - ([897c45b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/897c45bc3539cf8b3e861bfd5cc6a79d2a25c7b7))
+- *(axelar-gateway)* Emit event when upgrade is completed ([#85](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/85)) - ([7c17383](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7c17383e77b925e8f9d52f8d362b4e1918a6f377))
+- *(axelar-gateway)* Improve error handling ([#30](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/30)) - ([abf0636](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/abf063624a8a45afa696550051e2d3f14b3406d1))
+- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
+- *(example)* Update gmp example ([#66](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/66)) - ([a71b97a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a71b97af4cfb0f69cf0f4c3470132051d7c2c4c2))
+- *(gateway)* Differentiate gateway errors ([#109](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/109)) - ([6fa56a9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6fa56a9d38c35873be814b5b86e8edbea60e05e1))
+- *(gateway)* Add contract constructor ([#73](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/73)) - ([0ca13fe](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0ca13fe2fb8e81e1ac9bf13951b617f1d51bc7cc))
+- *(gateway)* Add instance ttl extension ([#51](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/51)) - ([12cba3b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/12cba3bd50b067556ca9d9744768c3812488b69e))
+- *(gateway)* Add external views for signers hash and epoch ([#48](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/48)) - ([51800c8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51800c8deeecaf9c72bbf003f684ac66c99440a9))
+- *(gateway)* Add ownership for upgrade ([#40](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/40)) - ([1e199d0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1e199d00720b9f6a98bf571804aed0a6f9023e4c))
+- *(gateway)* Prevent repeated signers ([#36](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/36)) - ([720f818](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/720f818981d9f6e2e7b42f5c497a05c28a73b0f5))
+- *(gateway)* Add upgrade and version ([#32](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/32)) - ([4f92de2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f92de25e41cf782769427da3be5e91b890a423f))
+- *(gateway)* Emit epoch on rotate signers event ([#31](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/31)) - ([ae1b9b8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ae1b9b85e74087e0f3cfa52a9b1ffc5cc18fac1f))
+- *(gateway)* [**breaking**] Update rotate signers event ([#28](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/28)) - ([06c85a0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/06c85a0e49456a845ea7d80598009ef8c38387e4))
+- *(gateway)* Add rotation delay governance ([#27](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/27)) - ([3baa011](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3baa011a082222a1cb1178955183eac5f62d5892))
+- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
+- *(its)* Update event test with new event test utils ([#114](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/114)) - ([1761b73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1761b733706f3e522d7cf060b04b697da878bee7))
+- *(soroban-sdk)* [**breaking**] Upgrade to soroban v21 preview ([#17](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/17)) - ([edfbb84](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/edfbb846f59079dbc29e72c6a0ae7820617ca108))
+- *(upgrader)* Add generalized atomic upgrade and migration capabilities ([#77](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/77)) - ([48507e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/48507e256ef91a89b0a7da1fb88cbb1a5ad5ebea))
+- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
+- The execute function of the ExecutableInterface trait returns a result ([#132](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/132)) - ([47d92ee](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47d92eec27cf9dc5d7a850a1e4a70f810a75da06))
+- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
+- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+- Allow exporting soroban contract crates are libraries ([#80](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/80)) - ([22cf5ab](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/22cf5ab2246c93834787f311f2b4898ae897cb75))
+- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
+- Update message approval args consistent ([#35](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/35)) - ([b6c315f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b6c315f36648453347689bc28a60bf5c7e7969c0))
+- Update call contract and rotate signers event ([#34](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/34)) - ([9309b4a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9309b4ad981f9b8bd606f40a7cafd8efec8207fb))
+- Update execute event ([#29](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/29)) - ([7355aad](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7355aade286a27f4dd2f55bbc35e9d79d205f668))
+- Gateway full test coverage ([#10](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/10)) - ([7783100](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7783100ce7e9b182f315cfffcf0eb59c64e3fee9))
+- Github actions ([#6](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/6)) - ([1e1841b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1e1841bd7d4a1f29086c622f11e9ac9016998d33))
+- Use auth client via dependency - ([aa36c2b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/aa36c2ba650d8ce46cf66282a12986dfbd5fb236))
+- Integrate auth verifier into axelar gateway - ([3b897f8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3b897f8bf4e387b6ea09bf02b8c3c864f5deaeeb))
+- Add gateway tests - ([5dbc277](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5dbc277fe924b5c1797064c638019d327a3f9b17))
+- Add gateway implementation - ([b1d3261](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b1d32611b3e01d2358bb67359eb6be60c9a8add9))
+- Add gateway batch types - ([c1339dc](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c1339dc455beb0f6cd7450306518885208ac39aa))
+- Add error types - ([6b4dff5](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6b4dff560eaf662fef6dd0094a485a30cdee3646))
+- Add call contract - ([2e615d7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2e615d7188d5551c08446331b99d22279cee9c16))
+- Add gateway events - ([4738da3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4738da3c8784c76a08247e4773e41e14c248c7f6))
+- Add storage types - ([6715eca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6715ecaab26662de1d3295d59ad9bb8feecd1c97))
+- Add gateway interface - ([954f5a9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/954f5a997a714d3316eedc1facd23202d3527b7f))
+- Use cargo workspace ([#2](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/2)) - ([7b98eeb](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b98eeb9dbbc46059bbd77b5dff2c6d0e7c161f5))
+
+### 🐛 Bug Fixes
+
+- *(axelar-gateway)* Ensure the testutils feature is loaded for tests ([#70](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/70)) - ([c4796c0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c4796c0e853a8d7d353aac1ec81fc6c2fd1921ba))
+- Keep rlib bindings for tests - ([6c5566f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6c5566f6d5d54467b4e67f5711e977cd66835aea))
+- Run cargo fmt - ([840df82](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/840df82b9239f396c0b1d07a6658550958a33643))
+- Remove dependence on auth contract wasm code - ([6f3be52](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6f3be52ebf874215977c0f8fb9eb5952fb9390f1))
+- Run clippy - ([ec9ab6f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ec9ab6f22faa9ef733d29fee676d238c6293bac2))
+- Ran cargo fmt and clippy - ([6e4bf1c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6e4bf1c7eae21a86816ca51ddf45cb3bc40001b4))
+- Support secp256k1 recovery id and fix tests - ([e8b661c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e8b661c3c3f4cebe5ea1be69e5c59f458ccf1c82))
+- Cargo fmt - ([9c1ce62](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9c1ce621a732bd8ae2bbee457a2d0e4efdb6e62c))
+- Remove unused deps and gate tests - ([61767e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/61767e243290f00b770ecd926ac96bbe88d13370))
+
+### 🚜 Refactor
+
+- *(axelar-gateway)* Use typed events ([#128](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/128)) - ([778ee8e](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/778ee8eea30b9feb73aacf922fc3c5fe32cd068d))
+- *(axelar-gateway)* [**breaking**] Separate gateway messaging interface ([#82](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/82)) - ([3bfc691](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3bfc6917081f277c4cfcbd3cd8ba25f161f3ed89))
+- *(axelar-gateway)* Move gateway types out of `axelar-soroban-interfaces` ([#42](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/42)) - ([c627336](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c627336421701f1c4038e0be92fdba4e66e0aaeb))
+- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
+- *(axelar-gateway)* [**breaking**] Merge gateway and auth verifier ([#23](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/23)) - ([41256ea](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/41256eaf4535f84af9a99eba32f01875ca700966))
+- *(upgrader)* Clean up the UpgraderInterface and simplify the contract ([#84](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/84)) - ([8f298ff](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8f298ff7585a29e6adef7cf29fdbf71c0c1e146b))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract operatorship management into sharable interface ([#98](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/98)) - ([faefa35](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/faefa35ad1547e3db5a467a4c9c50bb94d7b9260))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))
+- Create Hash type alias for BytesN<32> - ([d5c6418](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d5c64186632004c0d30cb8740a73657299c8ba53))
+- [**breaking**] Switch to external axelar gateway interface - ([1f1a8ac](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1f1a8acaf82cc917a13ae81540667e8679feb907))
+- Handle uninitialized error in the gateway - ([c6fc62a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c6fc62ade38c22d5deafa7d7c31eca301d4b54d7))
+- Remove superfluous CommandExecuted contract type - ([bba0824](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bba08246a81e968e19497a36c01d6b6b999ebd65))
+
+### ⚡ Performance
+
+- Remove rlib bindings from contracts - ([1ec04f6](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1ec04f617deddf9cd16af04f4d9be99f902cd564))
+- Check existence for approval key instead of getting the value - ([df9778d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df9778def0fcb74bb4744e65984bb75e445977b7))
+
+### 🧪 Testing
+
+- *(axelar-gateway)* Rework auth unit tests to integration tests ([#93](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/93)) - ([8fbbe1c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8fbbe1c15fc52c0ba663c9a050fb7fab636b06d5))
+- *(axelar-gateway)* Add golden test for weighted signers ([#37](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/37)) - ([0456b04](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0456b044076659c278dfb46868bf39323d8b5895))
+- *(axelar-gateway)* Re-introduce auth-verifier tests ([#33](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/33)) - ([bfcf45d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bfcf45d2a893a00fadf69a824ac696f350327582))
+- *(gateway)* Reuse domain separator for rotate signer tests - ([b80e35b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b80e35b66e39ab448f72db9e878c7423dd535a57))
 - Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))
 - Add expected invoke auth error for unit tests ([#52](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/52)) - ([890bfcf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/890bfcfc92badf0ffed2c90aa581efdac4ce81dc))
 - Support negative indexing for asserting emitted events - ([4d57a62](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d57a62689b4c93662efd8b78bdf6d772975db63))

--- a/contracts/axelar-operators/CHANGELOG.md
+++ b/contracts/axelar-operators/CHANGELOG.md
@@ -46,6 +46,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 
+* @talalashraf
+* @milapsheth
+* @TanvirDeol
+* @ahramy
+* @cgorenflo
+* @AttissNgo
+* @hydrobeam
+* @apolikamixitos
+* @re1ro
+* @deanamiel
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(Operators)* Execute method ([#15](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/15)) - ([20bbf95](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/20bbf95a6ba486f48c6ec116e31d34110f912880))
+- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
+- *(axelar-operators)* Improve error handling ([#24](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/24)) - ([c063879](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c063879442a39a0ea43beb5387516a10aee96670))
+- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
+- *(operators)* Add contract constructor ([#69](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/69)) - ([8db4014](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8db4014376ea5e2fc00c4a7d39e56e4952b01a9e))
+- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
+- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
+- Operators contract ([#14](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/14)) - ([81a8f0e](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/81a8f0e91d89fbae4c61d9fb5790250c892ff6a7))
+
+### 🚜 Refactor
+
+- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
+- *(gas-service,operators)* Move out of `axelar-soroban-interfaces` ([#43](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/43)) - ([c7a9d9f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c7a9d9f6b2f346efa4b1f836f00bd591eea84be8))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))
+
+### 🧪 Testing
+
+- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))
+
+### ⚙️ Miscellaneous Tasks
+
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
+- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
+- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))
+
+### Contributors
+
 * @milapsheth
 * @TanvirDeol
 * @ahramy

--- a/contracts/interchain-token-service/CHANGELOG.md
+++ b/contracts/interchain-token-service/CHANGELOG.md
@@ -15,6 +15,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(ITS)* Add ITS message ABI encoding/decoding support ([#65](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/65)) - ([9c49a73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9c49a73346d161b8bd52060ef764db04464ceb80))
 - *(ITS)* Allow owner to add/remove trusted addresses ([#39](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/39)) - ([6dddb12](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6dddb124a73c40de17b0e88aa570edeb6db4efc5))
 - *(axelar-soroban-std)* Allow typed matching of emitted events ([#92](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/92)) - ([7a410ca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7a410cab94a280777361e75c73675431b2c1be2f))
+- *(example)* Add interchain-token-service ([#149](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/149)) - ([b7784a7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b7784a70ef4811b613b8a0f6263f63e864e159bf))
+- *(interchain-token-service)* Add associated error types for ITS executable interface ([#142](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/142)) - ([7615a1f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7615a1f0c73f739dc8b8a631674bfcc00c14505a))
+- *(interchain-token-service)* Add pause/unpause ability ([#159](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/159)) - ([d9f465d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d9f465d94f41111e71d0561b621ac302680a7426))
+- *(interchain-token-service)* Encode source/recipient addresses as strings instead of XDR ([#147](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/147)) - ([2b3ca63](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2b3ca63d75535ad3260e50d72d24a07fa3cb761d))
+- *(interchain-token-service)* Handle stellar native asset metadata ([#155](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/155)) - ([87cb759](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/87cb759cf9a2790e054b88b2b30fd6f03af65574))
+- *(interchain-token-service)* Add flow limit ([#130](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/130)) - ([7da3677](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7da36774cfa4f44d7bd66de9ac04f8ed0d4c6160))
+- *(interchain-token-service)* Library export ([#126](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/126)) - ([7adc13d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7adc13d91bd322c9d62cebcca11aa63c7d9c5cbf))
+- *(interchain-token-service)* Deploy remote canonical token ([#123](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/123)) - ([bec2a07](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bec2a0723a4e42a6c1db0c435cc65f5a07898326))
+- *(interchain-token-service)* Process deploy interchain token message ([#122](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/122)) - ([bfc7ded](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bfc7ded743699b4e6d50d721876cd5c2f7db293b))
+- *(interchain-token-service)* Remote interchain token ([#118](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/118)) - ([6ec2622](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6ec26221bd6a7583b65bde93a2f69a7abb4dacb9))
+- *(interchain-token-service)* Register canonical interchain token ([#119](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/119)) - ([7cce18f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7cce18fbf483648456c11c799c334430d6475c46))
+- *(interchain-token-service)* Add interchain token executable ([#120](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/120)) - ([daf70ec](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/daf70ec484eb6c50fcf30ac0e0ca874fdea729ff))
+- *(interchain-token-service)* Add interchain_transfer implementation ([#115](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/115)) - ([ff1f206](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ff1f2068702f09babb3d0b3afe4a5ebee7f7bbdf))
+- *(interchain-token-service)* Store token id as token data ([#112](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/112)) - ([1ddfef5](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1ddfef51c8b9fc7689e90b233b2f3d9754d8d942))
+- *(interchain-token-service)* Deploy interchain token ([#99](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/99)) - ([bdf9443](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bdf9443d55f142a333a5d39a059c9f7479327ce4))
+- *(interchain-token-service)* Add message routing ([#90](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/90)) - ([e06032c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e06032cb8b90e2e8c78cd0a93a4dad4da588df75))
+- *(interchain-token-service,interchain-token)* Add contract constructor ([#74](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/74)) - ([4cbaab3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4cbaab3f1fed2878a1ad5259c40d361b85a4747f))
+- *(its)* Update event test with new event test utils ([#114](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/114)) - ([1761b73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1761b733706f3e522d7cf060b04b697da878bee7))
+- *(its)* Add skeleton code for its token deployment ([#88](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/88)) - ([b062cf1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b062cf1eb9f26ef2ceeebeded732fd40e58f48f4))
+- *(its)* Add ITS message types ([#55](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/55)) - ([9b62384](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9b6238401ccdd087c8a8d9a6516fc2537dcac8ba))
+- The execute function of the ExecutableInterface trait returns a result ([#132](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/132)) - ([47d92ee](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47d92eec27cf9dc5d7a850a1e4a70f810a75da06))
+- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
+- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
+
+### 🐛 Bug Fixes
+
+- *(interchain-token-service)* Validate its hub source address ([#156](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/156)) - ([4d88942](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d889422c4e4ea765c3f8bb20c79f80b5136a087))
+- *(interchain-token-service)* Fix flow limit storage and testing ([#148](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/148)) - ([006e7ca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/006e7ca128253438c1b461868d7d04815de05c39))
+- *(interchain-token-service)* Add destination validation checks ([#150](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/150)) - ([1b77756](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1b77756e62f35f7ac016dab7fbba9e2a06375e87))
+- *(interchain-token-service)* Update error handling for token id config ([#121](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/121)) - ([8430b93](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8430b939fe3a330161ee7318218a85ee6721254d))
+- *(interchain-token-service)* Revert on execute error ([#116](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/116)) - ([91533fc](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/91533fc4ff61aa3d7a3fc005cc52d8efbaf1f2ad))
+- *(its)* Move ITS test directory to the correct level ([#86](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/86)) - ([6639369](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6639369c916e2b839faa2227fc783e49704cb926))
+
+### 🚜 Refactor
+
+- *(interchain-token-service)* Cleanup its execute handlers ([#157](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/157)) - ([1a5876d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1a5876d89ac9eff147c728fd2ce778fdc2f1565c))
+- *(interchain-token-service)* Use IntoEvent derive macro ([#143](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/143)) - ([5800cf7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5800cf7bed4a7efefc7bebd037635968eff3ee99))
+- *(interchain-token-service)* Change trusted address to trusted chain ([#110](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/110)) - ([8798898](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8798898467d5c4e2d3e0de071386b3ca6944a53a))
+- *(its)* Add BytesExt trait ([#108](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/108)) - ([0b2d38a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0b2d38ab5cc8895e6038113db2e1f391e555b4fd))
+- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+
+### 📚 Documentation
+
+- *(interchain-token-service)* Move entrypoint docstring to interface ([#146](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/146)) - ([f9ec5a6](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f9ec5a66e8eb351ddea77fa23a48f57c7888adcf))
+
+### 🧪 Testing
+
+- *(interchain-token-service)* Test for error on execute failure ([#160](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/160)) - ([f02f600](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f02f600cc6c94cabbad707e62d6fa2b9324efa85))
+- Improve test coverage ([#163](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/163)) - ([d753e51](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d753e51b535c6234f81017a55e81046128c958bd))
+- Add expected invoke auth error for unit tests ([#52](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/52)) - ([890bfcf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/890bfcfc92badf0ffed2c90aa581efdac4ce81dc))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(its)* Move test.rs to tests folder ([#76](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/76)) - ([193c6ba](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/193c6bab049b90d80f80bc17de4d75ddd2d517bb))
+- Update workspace dependencies ([#158](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/158)) - ([f214826](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f214826c4695fdf0d25e6298a94c415fa8ea1ff0))
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+- Simplify auth test utils ([#125](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/125)) - ([8eba319](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8eba3199c09180f7db446ddcc25580ad935fbfcc))
+- Switch rust actions in workflows ([#107](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/107)) - ([480cb04](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/480cb04f311786545669a6f39a8a3a55950245e7))
+- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
+- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
+- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))
+
+### Contributors
+
+* @nbayindirli
+* @AttissNgo
+* @cgorenflo
+* @milapsheth
+* @TanvirDeol
+* @talalashraf
+* @ahramy
+* @hydrobeam
+* @apolikamixitos
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(ITS)* Add chain name and token deploy salt and token sdk to ITS ([#95](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/95)) - ([017d421](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/017d421eb8c131a84de1b49fca89a45b094e2da9))
+- *(ITS)* Add ITS message ABI encoding/decoding support ([#65](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/65)) - ([9c49a73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9c49a73346d161b8bd52060ef764db04464ceb80))
+- *(ITS)* Allow owner to add/remove trusted addresses ([#39](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/39)) - ([6dddb12](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6dddb124a73c40de17b0e88aa570edeb6db4efc5))
+- *(axelar-soroban-std)* Allow typed matching of emitted events ([#92](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/92)) - ([7a410ca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7a410cab94a280777361e75c73675431b2c1be2f))
 - *(interchain-token-service)* Add flow limit ([#130](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/130)) - ([7da3677](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7da36774cfa4f44d7bd66de9ac04f8ed0d4c6160))
 - *(interchain-token-service)* Library export ([#126](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/126)) - ([7adc13d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7adc13d91bd322c9d62cebcca11aa63c7d9c5cbf))
 - *(interchain-token-service)* Deploy remote canonical token ([#123](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/123)) - ([bec2a07](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bec2a0723a4e42a6c1db0c435cc65f5a07898326))

--- a/contracts/interchain-token/CHANGELOG.md
+++ b/contracts/interchain-token/CHANGELOG.md
@@ -25,6 +25,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚜 Refactor
 
+- *(interchain-token-service)* Cleanup its execute handlers ([#157](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/157)) - ([1a5876d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1a5876d89ac9eff147c728fd2ce778fdc2f1565c))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+
+### 🧪 Testing
+
+- Improve test coverage ([#163](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/163)) - ([d753e51](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d753e51b535c6234f81017a55e81046128c958bd))
+
+### ⚙️ Miscellaneous Tasks
+
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+- Rename dev_dependencies to dev-dependencies in interchain token ([#63](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/63)) - ([a7106c7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a7106c7633ea4d95470330880562ae1dfe9404ed))
+
+### Contributors
+
+* @AttissNgo
+* @milapsheth
+* @talalashraf
+* @TanvirDeol
+* @ahramy
+* @cgorenflo
+* @hydrobeam
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(ITS)* Add chain name and token deploy salt and token sdk to ITS ([#95](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/95)) - ([017d421](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/017d421eb8c131a84de1b49fca89a45b094e2da9))
+- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
+- *(interchain-token-service)* Deploy remote canonical token ([#123](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/123)) - ([bec2a07](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bec2a0723a4e42a6c1db0c435cc65f5a07898326))
+- *(interchain-token-service)* Remote interchain token ([#118](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/118)) - ([6ec2622](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6ec26221bd6a7583b65bde93a2f69a7abb4dacb9))
+- *(interchain-token-service)* Add interchain_transfer implementation ([#115](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/115)) - ([ff1f206](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ff1f2068702f09babb3d0b3afe4a5ebee7f7bbdf))
+- *(interchain-token-service)* Deploy interchain token ([#99](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/99)) - ([bdf9443](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bdf9443d55f142a333a5d39a059c9f7479327ce4))
+- *(interchain-token-service,interchain-token)* Add contract constructor ([#74](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/74)) - ([4cbaab3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4cbaab3f1fed2878a1ad5259c40d361b85a4747f))
+- *(its)* Add skeleton code for interchain token ([#56](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/56)) - ([a67775a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a67775a76d8195ed4ea89305ee2c9fd8eb087c25))
+- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
+- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+
+### 🚜 Refactor
+
 - Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
 - [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
 - Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))

--- a/contracts/upgrader/CHANGELOG.md
+++ b/contracts/upgrader/CHANGELOG.md
@@ -24,6 +24,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
 - Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
 
+### 🧪 Testing
+
+- Improve test coverage ([#163](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/163)) - ([d753e51](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d753e51b535c6234f81017a55e81046128c958bd))
+
+### ⚙️ Miscellaneous Tasks
+
+- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
+
+### Contributors
+
+* @AttissNgo
+* @talalashraf
+* @ahramy
+* @cgorenflo
+* @milapsheth
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- *(axelar-gateway)* Emit event when upgrade is completed ([#85](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/85)) - ([7c17383](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7c17383e77b925e8f9d52f8d362b4e1918a6f377))
+- *(upgrader)* Add generalized atomic upgrade and migration capabilities ([#77](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/77)) - ([48507e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/48507e256ef91a89b0a7da1fb88cbb1a5ad5ebea))
+- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
+
+### 🚜 Refactor
+
+- *(upgrader)* Clean up the UpgraderInterface and simplify the contract ([#84](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/84)) - ([8f298ff](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8f298ff7585a29e6adef7cf29fdbf71c0c1e146b))
+- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
+- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
+- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
+
 ### ⚙️ Miscellaneous Tasks
 
 - Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))

--- a/packages/axelar-std-derive/CHANGELOG.md
+++ b/packages/axelar-std-derive/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⛰️ Features
 
+- *(example)* Add interchain-token-service ([#149](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/149)) - ([b7784a7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b7784a70ef4811b613b8a0f6263f63e864e159bf))
+- *(interchain-token-service)* Add associated error types for ITS executable interface ([#142](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/142)) - ([7615a1f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7615a1f0c73f739dc8b8a631674bfcc00c14505a))
+- *(interchain-token-service)* Handle stellar native asset metadata ([#155](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/155)) - ([87cb759](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/87cb759cf9a2790e054b88b2b30fd6f03af65574))
+- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
+
+### 🚜 Refactor
+
+- Remove stellar axelar std ([#164](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/164)) - ([294b1d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/294b1d832002732a76bc69d8dd89174eb3c572f8))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+
+### Contributors
+
+* @ahramy
+* @nbayindirli
+* @cgorenflo
+* @milapsheth
+* @talalashraf
+* @TanvirDeol
+
+## [0.1.0]
+
+### ⛰️ Features
+
 - Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
 
 ### 🚜 Refactor

--- a/packages/axelar-std/CHANGELOG.md
+++ b/packages/axelar-std/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⛰️ Features
 
+- *(interchain-token-service)* Add associated error types for ITS executable interface ([#142](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/142)) - ([7615a1f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7615a1f0c73f739dc8b8a631674bfcc00c14505a))
+- *(interchain-token-service)* Encode source/recipient addresses as strings instead of XDR ([#147](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/147)) - ([2b3ca63](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2b3ca63d75535ad3260e50d72d24a07fa3cb761d))
+- *(interchain-token-service)* Handle stellar native asset metadata ([#155](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/155)) - ([87cb759](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/87cb759cf9a2790e054b88b2b30fd6f03af65574))
+- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
+
+### 🚜 Refactor
+
+- *(interchain-token-service)* Cleanup its execute handlers ([#157](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/157)) - ([1a5876d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1a5876d89ac9eff147c728fd2ce778fdc2f1565c))
+- Remove stellar axelar std ([#164](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/164)) - ([294b1d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/294b1d832002732a76bc69d8dd89174eb3c572f8))
+- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
+- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
+- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
+
+### 🧪 Testing
+
+- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update workspace dependencies ([#158](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/158)) - ([f214826](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f214826c4695fdf0d25e6298a94c415fa8ea1ff0))
+
+### Contributors
+
+* @ahramy
+* @cgorenflo
+* @milapsheth
+* @TanvirDeol
+* @talalashraf
+* @nbayindirli
+
+## [0.1.0]
+
+### ⛰️ Features
+
 - Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
 
 ### 🚜 Refactor


### PR DESCRIPTION

### [0.1.0]

Package: stellar-axelar-gas-service 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
- *(gas-service)* Add contract constructor ([#72](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/72)) - ([2d5e74c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2d5e74c5eaa07eb4ede4a287d13d6be25c5212b7))
- *(gas-service)* Add gas function in gas service ([#59](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/59)) - ([270bd85](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/270bd85c32f9cd90285134be1b4a9fd2878402ff))
- *(gas-service)* Improve error handling ([#26](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/26)) - ([d330956](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d330956385ebdfc37455a824ce4e66e106ae34e4))
- *(its)* Add skeleton code for its token deployment ([#88](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/88)) - ([b062cf1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b062cf1eb9f26ef2ceeebeded732fd40e58f48f4))
- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
- Allow exporting soroban contract crates are libraries ([#80](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/80)) - ([22cf5ab](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/22cf5ab2246c93834787f311f2b4898ae897cb75))
- Gmp example contract ([#62](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/62)) - ([fe4859d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/fe4859dd50e8ff922e8c363ae8c77ef0f772850a))
- Upgrade `soroban-sdk` version to `v21.7.6` ([#50](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/50)) - ([f4efa15](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f4efa1545926199c7deae8b864abc1858d9cb6a9))
- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
- Gas service ([#3](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/3)) - ([64fdccf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/64fdccf8131d045a2c2785f91d1c79999c89c4cd))

### 🐛 Bug Fixes

- *(axelar-gas-service)* [**breaking**] Fix axlear gas service add_gas ([#89](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/89)) - ([20593c0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/20593c021448fd0522fee003b1ae56a3b74f3dd7))
- *(axelar-gas-service)* [**breaking**] Fix axelar gas service pay_gas ([#83](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/83)) - ([6803ae7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6803ae766298c764b4fe8606af7a1309b8d2dff3))

### 🚜 Refactor

- *(axelar-gas-service)* Move run_migration into separate impl block ([#91](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/91)) - ([ce8d3af](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ce8d3af09bff15b85d94b5a2502806411a62374e))
- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
- *(gas-service,operators)* Move out of `axelar-soroban-interfaces` ([#43](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/43)) - ([c7a9d9f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c7a9d9f6b2f346efa4b1f836f00bd591eea84be8))
- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))

### ⚙️ Miscellaneous Tasks

- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))

### Contributors

* @TanvirDeol
* @ahramy
* @cgorenflo
* @AttissNgo
* @milapsheth
* @hydrobeam
* @apolikamixitos
* @canhtrinh



### [0.1.0]

Package: stellar-axelar-std 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))

### 🚜 Refactor

- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))

### 🧪 Testing

- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))

### Contributors

* @milapsheth
* @ahramy
* @nbayindirli
* @TanvirDeol



### [0.1.0]

Package: stellar-axelar-std-derive 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))

### 🚜 Refactor

- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))

### Contributors

* @nbayindirli
* @TanvirDeol
* @ahramy



### [0.1.0]

Package: stellar-axelar-gateway 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(amplifier)* Gateway v2 - ([948296d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/948296d1397e4ca93341b79e9f1d6f761edb99c6))
- *(amplifier)* Auth v2 - ([b455faa](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b455faac7600aa78fb0ebde2b4f48f1914cd154e))
- *(amplifier)* Add gateway v2 interface - ([897c45b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/897c45bc3539cf8b3e861bfd5cc6a79d2a25c7b7))
- *(axelar-gateway)* Emit event when upgrade is completed ([#85](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/85)) - ([7c17383](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7c17383e77b925e8f9d52f8d362b4e1918a6f377))
- *(axelar-gateway)* Improve error handling ([#30](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/30)) - ([abf0636](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/abf063624a8a45afa696550051e2d3f14b3406d1))
- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
- *(example)* Update gmp example ([#66](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/66)) - ([a71b97a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a71b97af4cfb0f69cf0f4c3470132051d7c2c4c2))
- *(gateway)* Differentiate gateway errors ([#109](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/109)) - ([6fa56a9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6fa56a9d38c35873be814b5b86e8edbea60e05e1))
- *(gateway)* Add contract constructor ([#73](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/73)) - ([0ca13fe](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0ca13fe2fb8e81e1ac9bf13951b617f1d51bc7cc))
- *(gateway)* Add instance ttl extension ([#51](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/51)) - ([12cba3b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/12cba3bd50b067556ca9d9744768c3812488b69e))
- *(gateway)* Add external views for signers hash and epoch ([#48](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/48)) - ([51800c8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51800c8deeecaf9c72bbf003f684ac66c99440a9))
- *(gateway)* Add ownership for upgrade ([#40](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/40)) - ([1e199d0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1e199d00720b9f6a98bf571804aed0a6f9023e4c))
- *(gateway)* Prevent repeated signers ([#36](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/36)) - ([720f818](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/720f818981d9f6e2e7b42f5c497a05c28a73b0f5))
- *(gateway)* Add upgrade and version ([#32](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/32)) - ([4f92de2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f92de25e41cf782769427da3be5e91b890a423f))
- *(gateway)* Emit epoch on rotate signers event ([#31](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/31)) - ([ae1b9b8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ae1b9b85e74087e0f3cfa52a9b1ffc5cc18fac1f))
- *(gateway)* [**breaking**] Update rotate signers event ([#28](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/28)) - ([06c85a0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/06c85a0e49456a845ea7d80598009ef8c38387e4))
- *(gateway)* Add rotation delay governance ([#27](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/27)) - ([3baa011](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3baa011a082222a1cb1178955183eac5f62d5892))
- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
- *(its)* Update event test with new event test utils ([#114](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/114)) - ([1761b73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1761b733706f3e522d7cf060b04b697da878bee7))
- *(soroban-sdk)* [**breaking**] Upgrade to soroban v21 preview ([#17](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/17)) - ([edfbb84](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/edfbb846f59079dbc29e72c6a0ae7820617ca108))
- *(upgrader)* Add generalized atomic upgrade and migration capabilities ([#77](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/77)) - ([48507e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/48507e256ef91a89b0a7da1fb88cbb1a5ad5ebea))
- Simplify event definition via IntoEvent derive macro ([#136](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/136)) - ([9052c78](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9052c7886b8d2ea12f33a1fdcceaa7d159890c4e))
- The execute function of the ExecutableInterface trait returns a result ([#132](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/132)) - ([47d92ee](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47d92eec27cf9dc5d7a850a1e4a70f810a75da06))
- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
- Allow exporting soroban contract crates are libraries ([#80](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/80)) - ([22cf5ab](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/22cf5ab2246c93834787f311f2b4898ae897cb75))
- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
- Update message approval args consistent ([#35](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/35)) - ([b6c315f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b6c315f36648453347689bc28a60bf5c7e7969c0))
- Update call contract and rotate signers event ([#34](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/34)) - ([9309b4a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9309b4ad981f9b8bd606f40a7cafd8efec8207fb))
- Update execute event ([#29](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/29)) - ([7355aad](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7355aade286a27f4dd2f55bbc35e9d79d205f668))
- Gateway full test coverage ([#10](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/10)) - ([7783100](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7783100ce7e9b182f315cfffcf0eb59c64e3fee9))
- Github actions ([#6](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/6)) - ([1e1841b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1e1841bd7d4a1f29086c622f11e9ac9016998d33))
- Use auth client via dependency - ([aa36c2b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/aa36c2ba650d8ce46cf66282a12986dfbd5fb236))
- Integrate auth verifier into axelar gateway - ([3b897f8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3b897f8bf4e387b6ea09bf02b8c3c864f5deaeeb))
- Add gateway tests - ([5dbc277](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5dbc277fe924b5c1797064c638019d327a3f9b17))
- Add gateway implementation - ([b1d3261](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b1d32611b3e01d2358bb67359eb6be60c9a8add9))
- Add gateway batch types - ([c1339dc](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c1339dc455beb0f6cd7450306518885208ac39aa))
- Add error types - ([6b4dff5](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6b4dff560eaf662fef6dd0094a485a30cdee3646))
- Add call contract - ([2e615d7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2e615d7188d5551c08446331b99d22279cee9c16))
- Add gateway events - ([4738da3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4738da3c8784c76a08247e4773e41e14c248c7f6))
- Add storage types - ([6715eca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6715ecaab26662de1d3295d59ad9bb8feecd1c97))
- Add gateway interface - ([954f5a9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/954f5a997a714d3316eedc1facd23202d3527b7f))
- Use cargo workspace ([#2](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/2)) - ([7b98eeb](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b98eeb9dbbc46059bbd77b5dff2c6d0e7c161f5))

### 🐛 Bug Fixes

- *(axelar-gateway)* Ensure the testutils feature is loaded for tests ([#70](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/70)) - ([c4796c0](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c4796c0e853a8d7d353aac1ec81fc6c2fd1921ba))
- Keep rlib bindings for tests - ([6c5566f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6c5566f6d5d54467b4e67f5711e977cd66835aea))
- Run cargo fmt - ([840df82](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/840df82b9239f396c0b1d07a6658550958a33643))
- Remove dependence on auth contract wasm code - ([6f3be52](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6f3be52ebf874215977c0f8fb9eb5952fb9390f1))
- Run clippy - ([ec9ab6f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ec9ab6f22faa9ef733d29fee676d238c6293bac2))
- Ran cargo fmt and clippy - ([6e4bf1c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6e4bf1c7eae21a86816ca51ddf45cb3bc40001b4))
- Support secp256k1 recovery id and fix tests - ([e8b661c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e8b661c3c3f4cebe5ea1be69e5c59f458ccf1c82))
- Cargo fmt - ([9c1ce62](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9c1ce621a732bd8ae2bbee457a2d0e4efdb6e62c))
- Remove unused deps and gate tests - ([61767e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/61767e243290f00b770ecd926ac96bbe88d13370))

### 🚜 Refactor

- *(axelar-gateway)* Use typed events ([#128](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/128)) - ([778ee8e](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/778ee8eea30b9feb73aacf922fc3c5fe32cd068d))
- *(axelar-gateway)* [**breaking**] Separate gateway messaging interface ([#82](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/82)) - ([3bfc691](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3bfc6917081f277c4cfcbd3cd8ba25f161f3ed89))
- *(axelar-gateway)* Move gateway types out of `axelar-soroban-interfaces` ([#42](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/42)) - ([c627336](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c627336421701f1c4038e0be92fdba4e66e0aaeb))
- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
- *(axelar-gateway)* [**breaking**] Merge gateway and auth verifier ([#23](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/23)) - ([41256ea](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/41256eaf4535f84af9a99eba32f01875ca700966))
- *(upgrader)* Clean up the UpgraderInterface and simplify the contract ([#84](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/84)) - ([8f298ff](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8f298ff7585a29e6adef7cf29fdbf71c0c1e146b))
- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract operatorship management into sharable interface ([#98](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/98)) - ([faefa35](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/faefa35ad1547e3db5a467a4c9c50bb94d7b9260))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))
- Create Hash type alias for BytesN<32> - ([d5c6418](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d5c64186632004c0d30cb8740a73657299c8ba53))
- [**breaking**] Switch to external axelar gateway interface - ([1f1a8ac](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1f1a8acaf82cc917a13ae81540667e8679feb907))
- Handle uninitialized error in the gateway - ([c6fc62a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c6fc62ade38c22d5deafa7d7c31eca301d4b54d7))
- Remove superfluous CommandExecuted contract type - ([bba0824](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bba08246a81e968e19497a36c01d6b6b999ebd65))

### ⚡ Performance

- Remove rlib bindings from contracts - ([1ec04f6](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1ec04f617deddf9cd16af04f4d9be99f902cd564))
- Check existence for approval key instead of getting the value - ([df9778d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df9778def0fcb74bb4744e65984bb75e445977b7))

### 🧪 Testing

- *(axelar-gateway)* Rework auth unit tests to integration tests ([#93](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/93)) - ([8fbbe1c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8fbbe1c15fc52c0ba663c9a050fb7fab636b06d5))
- *(axelar-gateway)* Add golden test for weighted signers ([#37](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/37)) - ([0456b04](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0456b044076659c278dfb46868bf39323d8b5895))
- *(axelar-gateway)* Re-introduce auth-verifier tests ([#33](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/33)) - ([bfcf45d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bfcf45d2a893a00fadf69a824ac696f350327582))
- *(gateway)* Reuse domain separator for rotate signer tests - ([b80e35b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b80e35b66e39ab448f72db9e878c7423dd535a57))
- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))
- Add expected invoke auth error for unit tests ([#52](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/52)) - ([890bfcf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/890bfcfc92badf0ffed2c90aa581efdac4ce81dc))
- Support negative indexing for asserting emitted events - ([4d57a62](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d57a62689b4c93662efd8b78bdf6d772975db63))
- Add axelar-gateway testutils - ([360263a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/360263a90778490a9b6e0e9a579314118e099b43))
- Use auth testutil initialize in gateway tests - ([d885c00](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d885c00012120b39ba8895d5bc88df67a07ede1c))
- Make axelar gateway tests use auth testutils - ([e602831](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e6028310a5adcd75c315f82f697aa7886bcfa6dd))
- Refactor gateway test to use testutils - ([3ee43f8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3ee43f89fd7a15612da69cfc534dd19117aced87))
- Simplify testutils using IntoVal<> - ([9779bef](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9779bef9a70564f1222f227d852b8620fa446d85))
- Fix test compilation issues - ([5c5b715](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5c5b71562b72dcf0d9b32747ee4b81175267b00e))

### ⚙️ Miscellaneous Tasks

- *(gateway)* Coverage for upgrade and version ([#45](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/45)) - ([0a40b39](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0a40b3945877d9d62ab8f0f16f8cda6945a4116e))
- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))
- Cargo sort - ([3e08c3b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e08c3beab4cf91d1513417febf5d1618685432f))
- Lint files - ([756cc99](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/756cc99b8a5823cbad6a1761546af28d56da3636))
- Remove duplicate gateway interface - ([23c86b2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/23c86b2cf03c3a6ca1a8c8192c3346175fcf2700))
- Add gateway contract TODOs - ([0802231](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0802231237037c3ffea026433d0c426e2d5b2f42))
- Add gateway as a dep to workspace - ([1cb795d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1cb795d5804d4009c209def50d71507690fb5331))
- Cargo fmt axelar gateway - ([7d07fdb](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7d07fdb02b9d513da6e299f20fc6262fd0c8f65c))

### Contributors

* @milapsheth
* @nbayindirli
* @TanvirDeol
* @ahramy
* @cgorenflo
* @AttissNgo
* @hydrobeam
* @apolikamixitos
* @deanamiel



### [0.1.0]

Package: stellar-axelar-operators 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(Operators)* Execute method ([#15](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/15)) - ([20bbf95](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/20bbf95a6ba486f48c6ec116e31d34110f912880))
- *(axelar-gateway)* Increase gateway coverage and add coverage report ([#25](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/25)) - ([2c6f9f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/2c6f9f96f59b74d521aec090d9e31908ab307134))
- *(axelar-operators)* Improve error handling ([#24](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/24)) - ([c063879](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c063879442a39a0ea43beb5387516a10aee96670))
- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
- *(operators)* Add contract constructor ([#69](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/69)) - ([8db4014](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8db4014376ea5e2fc00c4a7d39e56e4952b01a9e))
- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))
- Operators contract ([#14](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/14)) - ([81a8f0e](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/81a8f0e91d89fbae4c61d9fb5790250c892ff6a7))

### 🚜 Refactor

- *(axelar-gateway)* [**breaking**] Use more readable event symbols ([#41](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/41)) - ([3e7d28a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/3e7d28a8806fec2c689989b2e50de1860587190c))
- *(gas-service,operators)* Move out of `axelar-soroban-interfaces` ([#43](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/43)) - ([c7a9d9f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/c7a9d9f6b2f346efa4b1f836f00bd591eea84be8))
- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))
- Move contract tests to integration tests ([#49](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/49)) - ([5ed9513](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5ed95130e5cc11690d0738c427adaa2b61ad4c90))

### 🧪 Testing

- Check auth is used in assert_auth ([#151](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/151)) - ([4d8e920](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4d8e92065d528cd48a08319449b80f32322e5b08))

### ⚙️ Miscellaneous Tasks

- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))

### Contributors

* @milapsheth
* @TanvirDeol
* @ahramy
* @cgorenflo
* @AttissNgo
* @hydrobeam
* @apolikamixitos
* @re1ro
* @deanamiel



### [0.1.0]

Package: stellar-interchain-token 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(ITS)* Add chain name and token deploy salt and token sdk to ITS ([#95](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/95)) - ([017d421](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/017d421eb8c131a84de1b49fca89a45b094e2da9))
- *(interchain-token)* Update interchain token ([#71](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/71)) - ([6440cf8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6440cf86ea665ed72e8515c0fb01d4fc93f2f63d))
- *(interchain-token-service)* Deploy remote canonical token ([#123](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/123)) - ([bec2a07](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bec2a0723a4e42a6c1db0c435cc65f5a07898326))
- *(interchain-token-service)* Remote interchain token ([#118](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/118)) - ([6ec2622](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6ec26221bd6a7583b65bde93a2f69a7abb4dacb9))
- *(interchain-token-service)* Add interchain_transfer implementation ([#115](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/115)) - ([ff1f206](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ff1f2068702f09babb3d0b3afe4a5ebee7f7bbdf))
- *(interchain-token-service)* Deploy interchain token ([#99](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/99)) - ([bdf9443](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bdf9443d55f142a333a5d39a059c9f7479327ce4))
- *(interchain-token-service,interchain-token)* Add contract constructor ([#74](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/74)) - ([4cbaab3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4cbaab3f1fed2878a1ad5259c40d361b85a4747f))
- *(its)* Add skeleton code for interchain token ([#56](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/56)) - ([a67775a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a67775a76d8195ed4ea89305ee2c9fd8eb087c25))
- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))

### 🚜 Refactor

- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))

### ⚙️ Miscellaneous Tasks

- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
- Rename dev_dependencies to dev-dependencies in interchain token ([#63](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/63)) - ([a7106c7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/a7106c7633ea4d95470330880562ae1dfe9404ed))

### Contributors

* @TanvirDeol
* @ahramy
* @cgorenflo
* @AttissNgo
* @milapsheth
* @hydrobeam



### [0.1.0]

Package: stellar-interchain-token-service 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(ITS)* Add chain name and token deploy salt and token sdk to ITS ([#95](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/95)) - ([017d421](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/017d421eb8c131a84de1b49fca89a45b094e2da9))
- *(ITS)* Add ITS message ABI encoding/decoding support ([#65](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/65)) - ([9c49a73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9c49a73346d161b8bd52060ef764db04464ceb80))
- *(ITS)* Allow owner to add/remove trusted addresses ([#39](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/39)) - ([6dddb12](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6dddb124a73c40de17b0e88aa570edeb6db4efc5))
- *(axelar-soroban-std)* Allow typed matching of emitted events ([#92](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/92)) - ([7a410ca](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7a410cab94a280777361e75c73675431b2c1be2f))
- *(interchain-token-service)* Add flow limit ([#130](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/130)) - ([7da3677](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7da36774cfa4f44d7bd66de9ac04f8ed0d4c6160))
- *(interchain-token-service)* Library export ([#126](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/126)) - ([7adc13d](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7adc13d91bd322c9d62cebcca11aa63c7d9c5cbf))
- *(interchain-token-service)* Deploy remote canonical token ([#123](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/123)) - ([bec2a07](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bec2a0723a4e42a6c1db0c435cc65f5a07898326))
- *(interchain-token-service)* Process deploy interchain token message ([#122](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/122)) - ([bfc7ded](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bfc7ded743699b4e6d50d721876cd5c2f7db293b))
- *(interchain-token-service)* Remote interchain token ([#118](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/118)) - ([6ec2622](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6ec26221bd6a7583b65bde93a2f69a7abb4dacb9))
- *(interchain-token-service)* Register canonical interchain token ([#119](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/119)) - ([7cce18f](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7cce18fbf483648456c11c799c334430d6475c46))
- *(interchain-token-service)* Add interchain token executable ([#120](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/120)) - ([daf70ec](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/daf70ec484eb6c50fcf30ac0e0ca874fdea729ff))
- *(interchain-token-service)* Add interchain_transfer implementation ([#115](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/115)) - ([ff1f206](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ff1f2068702f09babb3d0b3afe4a5ebee7f7bbdf))
- *(interchain-token-service)* Store token id as token data ([#112](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/112)) - ([1ddfef5](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1ddfef51c8b9fc7689e90b233b2f3d9754d8d942))
- *(interchain-token-service)* Deploy interchain token ([#99](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/99)) - ([bdf9443](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bdf9443d55f142a333a5d39a059c9f7479327ce4))
- *(interchain-token-service)* Add message routing ([#90](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/90)) - ([e06032c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e06032cb8b90e2e8c78cd0a93a4dad4da588df75))
- *(interchain-token-service,interchain-token)* Add contract constructor ([#74](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/74)) - ([4cbaab3](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4cbaab3f1fed2878a1ad5259c40d361b85a4747f))
- *(its)* Update event test with new event test utils ([#114](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/114)) - ([1761b73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1761b733706f3e522d7cf060b04b697da878bee7))
- *(its)* Add skeleton code for its token deployment ([#88](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/88)) - ([b062cf1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/b062cf1eb9f26ef2ceeebeded732fd40e58f48f4))
- *(its)* Add ITS message types ([#55](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/55)) - ([9b62384](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9b6238401ccdd087c8a8d9a6516fc2537dcac8ba))
- The execute function of the ExecutableInterface trait returns a result ([#132](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/132)) - ([47d92ee](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47d92eec27cf9dc5d7a850a1e4a70f810a75da06))
- Add extend ttl to all contracts ([#124](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/124)) - ([ab4361c](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/ab4361c58daffebd099ab386910b55a4d56d152f))
- Add macros for shared interfaces ([#105](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/105)) - ([4f513f9](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4f513f933d290cc9cc5944e5e39bcda13a136906))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))
- Raise clippy lint level to `clippy::nursery` and apply lints ([#47](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/47)) - ([52951e1](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/52951e11f500b83f6cb31a3cadb845c4841af6a4))

### 🐛 Bug Fixes

- *(interchain-token-service)* Add destination validation checks ([#150](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/150)) - ([1b77756](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/1b77756e62f35f7ac016dab7fbba9e2a06375e87))
- *(interchain-token-service)* Update error handling for token id config ([#121](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/121)) - ([8430b93](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8430b939fe3a330161ee7318218a85ee6721254d))
- *(interchain-token-service)* Revert on execute error ([#116](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/116)) - ([91533fc](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/91533fc4ff61aa3d7a3fc005cc52d8efbaf1f2ad))
- *(its)* Move ITS test directory to the correct level ([#86](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/86)) - ([6639369](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/6639369c916e2b839faa2227fc783e49704cb926))

### 🚜 Refactor

- *(interchain-token-service)* Use IntoEvent derive macro ([#143](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/143)) - ([5800cf7](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/5800cf7bed4a7efefc7bebd037635968eff3ee99))
- *(interchain-token-service)* Change trusted address to trusted chain ([#110](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/110)) - ([8798898](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8798898467d5c4e2d3e0de071386b3ca6944a53a))
- *(its)* Add BytesExt trait ([#108](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/108)) - ([0b2d38a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/0b2d38ab5cc8895e6038113db2e1f391e555b4fd))
- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
- Rename assert_auth macros ([#138](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/138)) - ([8239e41](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8239e4126cdccb4156f737dd6e20fad5c2bfc239))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))

### 📚 Documentation

- *(interchain-token-service)* Move entrypoint docstring to interface ([#146](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/146)) - ([f9ec5a6](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/f9ec5a66e8eb351ddea77fa23a48f57c7888adcf))

### 🧪 Testing

- Add expected invoke auth error for unit tests ([#52](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/52)) - ([890bfcf](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/890bfcfc92badf0ffed2c90aa581efdac4ce81dc))

### ⚙️ Miscellaneous Tasks

- *(its)* Move test.rs to tests folder ([#76](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/76)) - ([193c6ba](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/193c6bab049b90d80f80bc17de4d75ddd2d517bb))
- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))
- Simplify auth test utils ([#125](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/125)) - ([8eba319](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8eba3199c09180f7db446ddcc25580ad935fbfcc))
- Switch rust actions in workflows ([#107](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/107)) - ([480cb04](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/480cb04f311786545669a6f39a8a3a55950245e7))
- Add the support for release pipeline ([#54](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/54)) - ([90d4368](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/90d436811258b54ee8efbac074da515e977eb47e))
- Rename dev_dependencies to dev-dependencies ([#61](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/61)) - ([47c6576](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/47c657656cf83105c46b64b98d85c0653212d528))
- Remove `axelar-soroban-interfaces` crate ([#46](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/46)) - ([514d8a4](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/514d8a441ab30587dd953004894596147298fec7))

### Contributors

* @ahramy
* @nbayindirli
* @AttissNgo
* @TanvirDeol
* @cgorenflo
* @milapsheth
* @hydrobeam
* @apolikamixitos



### [0.1.0]

Package: stellar-upgrader 0.1.0 -> 0.1.0

Changes:
### ⛰️ Features

- *(axelar-gateway)* Emit event when upgrade is completed ([#85](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/85)) - ([7c17383](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7c17383e77b925e8f9d52f8d362b4e1918a6f377))
- *(upgrader)* Add generalized atomic upgrade and migration capabilities ([#77](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/77)) - ([48507e2](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/48507e256ef91a89b0a7da1fb88cbb1a5ad5ebea))
- Add upgrade capabilities to all contracts ([#87](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/87)) - ([9785e8b](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/9785e8bebea93e987af664cedea3234241675d96))

### 🚜 Refactor

- *(upgrader)* Clean up the UpgraderInterface and simplify the contract ([#84](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/84)) - ([8f298ff](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/8f298ff7585a29e6adef7cf29fdbf71c0c1e146b))
- Update mock auth macro to support non root auth  ([#134](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/134)) - ([7b6a553](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/7b6a55385fc0bdcbd7d6bf065ddaa0f81dceb51f))
- [**breaking**] Update package name and references for release ([#145](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/145)) - ([bb19538](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/bb195386eeda9c75d4da33eb0cf29fd9cb9b621c))
- Restrict exports to contract and contract clients ([#103](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/103)) - ([4c25023](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/4c250237afce95fcd687f74e350b6b272a3d295d))
- Extract ownership management into sharable interface ([#97](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/97)) - ([df2d7d8](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/df2d7d8106e26c143757d26dfc321ffd5778d23b))
- Move shared interfaces in preparation of ownership trait extraction ([#96](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/96)) - ([e63006a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e63006a4f17abccbd1922389f1c03cc1735220b3))

### ⚙️ Miscellaneous Tasks

- Use rustfmt nightly build to introduce opinionated imports ordering ([#141](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/141)) - ([e19f588](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/e19f5887dcb7f648d1aacb0fedbd6dfa9bf45eb2))

### Contributors

* @ahramy
* @cgorenflo
* @milapsheth

