### PR TITLE
chore: release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,7 +1964,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-axelar-gas-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cfg-if",
  "goldie",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-axelar-gateway"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cfg-if",
  "ed25519-dalek",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-axelar-operators"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "goldie",
  "paste",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-axelar-std"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "goldie",
  "hex",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-interchain-token"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cfg-if",
  "goldie",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-interchain-token-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "stellar-upgrader"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "soroban-sdk",
  "stellar-axelar-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ proc-macro2 = { version = "1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 soroban-sdk = { version = "22.0.5" }
 soroban-token-sdk = { version = "22.0.5" }
-stellar-axelar-gas-service = { version = "^0.2.1", path = "contracts/stellar-axelar-gas-service" }
-stellar-axelar-gateway = { version = "^0.2.1", path = "contracts/stellar-axelar-gateway" }
-stellar-axelar-operators = { version = "^0.2.1", path = "contracts/stellar-axelar-operators" }
-stellar-axelar-std = { version = "^0.2.1", path = "packages/stellar-axelar-std", features = ["derive"] }
+stellar-axelar-gas-service = { version = "^0.2.2", path = "contracts/stellar-axelar-gas-service" }
+stellar-axelar-gateway = { version = "^0.2.2", path = "contracts/stellar-axelar-gateway" }
+stellar-axelar-operators = { version = "^0.2.2", path = "contracts/stellar-axelar-operators" }
+stellar-axelar-std = { version = "^0.2.2", path = "packages/stellar-axelar-std", features = ["derive"] }
 stellar-axelar-std-derive = { version = "^0.2.1", path = "packages/stellar-axelar-std-derive" }
 stellar-example = { version = "^0.1.0", path = "contracts/stellar-example" }
-stellar-interchain-token = { version = "^0.2.1", path = "contracts/stellar-interchain-token" }
-stellar-interchain-token-service = { version = "^0.2.1", path = "contracts/stellar-interchain-token-service" }
+stellar-interchain-token = { version = "^0.2.2", path = "contracts/stellar-interchain-token" }
+stellar-interchain-token-service = { version = "^0.2.2", path = "contracts/stellar-interchain-token-service" }
 
 [workspace.lints.clippy]
 nursery = { level = "warn", priority = -1 }

--- a/contracts/stellar-axelar-gas-service/CHANGELOG.md
+++ b/contracts/stellar-axelar-gas-service/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gas-service-v0.2.1...stellar-axelar-gas-service-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gas-service-v0.2.0...stellar-axelar-gas-service-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-axelar-gas-service/Cargo.toml
+++ b/contracts/stellar-axelar-gas-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-gas-service"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Axelar Gas Service."
 license = { workspace = true }

--- a/contracts/stellar-axelar-gateway/CHANGELOG.md
+++ b/contracts/stellar-axelar-gateway/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gateway-v0.2.1...stellar-axelar-gateway-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gateway-v0.2.0...stellar-axelar-gateway-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-axelar-gateway/Cargo.toml
+++ b/contracts/stellar-axelar-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-gateway"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Axelar Gateway."
 license = { workspace = true }

--- a/contracts/stellar-axelar-operators/CHANGELOG.md
+++ b/contracts/stellar-axelar-operators/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-operators-v0.2.1...stellar-axelar-operators-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-operators-v0.2.0...stellar-axelar-operators-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-axelar-operators/Cargo.toml
+++ b/contracts/stellar-axelar-operators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-operators"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Axelar Operators."
 license = { workspace = true }

--- a/contracts/stellar-interchain-token-service/CHANGELOG.md
+++ b/contracts/stellar-interchain-token-service/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-service-v0.2.1...stellar-interchain-token-service-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(its)* Remove unused IntoVal imports ([#200](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/200)) - ([d68aa73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d68aa730fb3f44e559387001a6ebe528fe087666))
+
+### Contributors
+
+* @nbayindirli
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-service-v0.2.0...stellar-interchain-token-service-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-interchain-token-service/Cargo.toml
+++ b/contracts/stellar-interchain-token-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-interchain-token-service"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Interchain Token Service."
 license = { workspace = true }

--- a/contracts/stellar-interchain-token/CHANGELOG.md
+++ b/contracts/stellar-interchain-token/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-v0.2.1...stellar-interchain-token-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-v0.2.0...stellar-interchain-token-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-interchain-token/Cargo.toml
+++ b/contracts/stellar-interchain-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-interchain-token"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Interchain Token."
 license = { workspace = true }

--- a/contracts/stellar-upgrader/CHANGELOG.md
+++ b/contracts/stellar-upgrader/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-upgrader-v0.2.1...stellar-upgrader-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-upgrader-v0.2.0...stellar-upgrader-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/contracts/stellar-upgrader/Cargo.toml
+++ b/contracts/stellar-upgrader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-upgrader"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Upgrader."
 license = { workspace = true }

--- a/packages/stellar-axelar-std/CHANGELOG.md
+++ b/packages/stellar-axelar-std/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-std-v0.2.1...stellar-axelar-std-v0.2.2)
+
+### 🚜 Refactor
+
+- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))
+
+### Contributors
+
+* @AttissNgo
+
 ## [0.2.1](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-std-v0.2.0...stellar-axelar-std-v0.2.1)
 
 ### ⚙️ Miscellaneous Tasks

--- a/packages/stellar-axelar-std/Cargo.toml
+++ b/packages/stellar-axelar-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-axelar-std"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 description = "Contract related to Stellar Axelar Std."
 license = { workspace = true }


### PR DESCRIPTION


### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gas-service-v0.2.1...stellar-axelar-gas-service-v0.2.2)

Package: stellar-axelar-gas-service 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-std-v0.2.1...stellar-axelar-std-v0.2.2)

Package: stellar-axelar-std 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-gateway-v0.2.1...stellar-axelar-gateway-v0.2.2)

Package: stellar-axelar-gateway 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-axelar-operators-v0.2.1...stellar-axelar-operators-v0.2.2)

Package: stellar-axelar-operators 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-service-v0.2.1...stellar-interchain-token-service-v0.2.2)

Package: stellar-interchain-token-service 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### ⚙️ Miscellaneous Tasks

- *(its)* Remove unused IntoVal imports ([#200](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/200)) - ([d68aa73](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/d68aa730fb3f44e559387001a6ebe528fe087666))

### Contributors

* @nbayindirli
* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-interchain-token-v0.2.1...stellar-interchain-token-v0.2.2)

Package: stellar-interchain-token 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo



### [0.2.2](https://github.com/axelarnetwork/axelar-cgp-stellar/compare/stellar-upgrader-v0.2.1...stellar-upgrader-v0.2.2)

Package: stellar-upgrader 0.2.1 -> 0.2.2

Changes:
### 🚜 Refactor

- Move test modules into lib.rs ([#199](https://github.com/axelarnetwork/axelar-cgp-stellar/pull/199)) - ([51a638a](https://github.com/axelarnetwork/axelar-cgp-stellar/commit/51a638a52bdaebc4928aab9e191b28a90e73f338))

### Contributors

* @AttissNgo

